### PR TITLE
Ruff config

### DIFF
--- a/.docker/lint.Dockerfile
+++ b/.docker/lint.Dockerfile
@@ -32,4 +32,4 @@ ENV VIRTUAL_ENV=/venvs/.venv \
 COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
 COPY app /app
-COPY pyproject.toml .flake8 ./
+COPY pyproject.toml ./

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-extend-ignore = S101, I900, G004, IF100, S311, D301, E231
-exclude =
-    app/alembic
-    alembic

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -28,26 +28,6 @@ jobs:
           NEW_TAG: linter
         run: docker run $NEW_TAG ruff check
 
-  flake8:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: build linters
-        env:
-          TAG: ghcr.io/${{ env.REPO }}_linters:latest
-          NEW_TAG: linter
-        run: docker build --target=runtime -f .docker/lint.Dockerfile . -t $NEW_TAG --cache-to type=gha,mode=max --cache-from $TAG --build-arg BUILDKIT_INLINE_CACHE=1
-      - name: Run linters
-        env:
-          NEW_TAG: linter
-        run: docker run $NEW_TAG flake8
-
   mypy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run linters
         env:
           NEW_TAG: linter
-        run: docker run $NEW_TAG ruff check
+        run: docker run $NEW_TAG ruff check --output-format=github .
 
   mypy:
     runs-on: ubuntu-latest

--- a/.kerberos/config_server.py
+++ b/.kerberos/config_server.py
@@ -688,9 +688,7 @@ def get_status(request: Request) -> bool:
     """
     kadmind = getattr(request.app.state, "kadmind", None)
 
-    if kadmind is not None:
-        return True
-    return False
+    return kadmind is not None
 
 
 def create_app() -> FastAPI:

--- a/.kerberos/config_server.py
+++ b/.kerberos/config_server.py
@@ -92,7 +92,10 @@ class AbstractKRBManager(ABC):
 
     @abstractmethod
     async def add_princ(
-        self, name: str, password: str | None, **dbargs,
+        self,
+        name: str,
+        password: str | None,
+        **dbargs,
     ) -> None:
         """Create principal.
 
@@ -202,7 +205,10 @@ class KAdminLocalManager(AbstractKRBManager):
         return await self.loop.run_in_executor(self.pool, kadmv.local)
 
     async def add_princ(
-        self, name: str, password: str | None, **dbargs,
+        self,
+        name: str,
+        password: str | None,
+        **dbargs,
     ) -> None:
         """Create principal.
 
@@ -210,7 +216,10 @@ class KAdminLocalManager(AbstractKRBManager):
         :param str | None password: if empty - uses randkey.
         """
         await self.loop.run_in_executor(
-            self.pool, self.client.add_principal, name, password,
+            self.pool,
+            self.client.add_principal,
+            name,
+            password,
         )
 
         princ = await self._get_raw_principal(name)
@@ -229,7 +238,9 @@ class KAdminLocalManager(AbstractKRBManager):
 
     async def _get_raw_principal(self, name: str) -> PrincipalProtocol:
         principal = await self.loop.run_in_executor(
-            self.pool, self.client.getprinc, name,
+            self.pool,
+            self.client.getprinc,
+            name,
         )
 
         if not principal:
@@ -254,7 +265,9 @@ class KAdminLocalManager(AbstractKRBManager):
         """
         princ = await self._get_raw_principal(name)
         await self.loop.run_in_executor(
-            self.pool, princ.change_password, new_password,
+            self.pool,
+            princ.change_password,
+            new_password,
         )
 
     async def create_or_update_princ_pw(self, name: str, new_password) -> None:
@@ -282,7 +295,10 @@ class KAdminLocalManager(AbstractKRBManager):
         :param str new_name: new name
         """
         await self.loop.run_in_executor(
-            self.pool, self.client.rename_principal, name, new_name,
+            self.pool,
+            self.client.rename_principal,
+            name,
+            new_name,
         )
 
     async def ktadd(self, names: list[str], fn: str) -> None:
@@ -393,21 +409,24 @@ def get_kadmin() -> KAdminLocalManager:
 def handle_db_error(request: Request, exc: BaseException):
     """Handle duplicate."""
     raise HTTPException(
-        status.HTTP_424_FAILED_DEPENDENCY, detail="Database Error",
+        status.HTTP_424_FAILED_DEPENDENCY,
+        detail="Database Error",
     )
 
 
 def handle_duplicate(request: Request, exc: BaseException):
     """Handle duplicate."""
     raise HTTPException(
-        status.HTTP_409_CONFLICT, detail="Principal already exists",
+        status.HTTP_409_CONFLICT,
+        detail="Principal already exists",
     )
 
 
 def handle_not_found(request: Request, exc: BaseException):
     """Handle duplicate."""
     raise HTTPException(
-        status.HTTP_404_NOT_FOUND, detail="Principal does not exist",
+        status.HTTP_404_NOT_FOUND,
+        detail="Principal does not exist",
     )
 
 
@@ -597,7 +616,8 @@ async def change_princ_password(
 
 
 @principal_router.post(
-    "/create_or_update", status_code=201,
+    "/create_or_update",
+    status_code=201,
     response_class=Response,
 )
 async def create_or_update_princ_password(
@@ -615,7 +635,8 @@ async def create_or_update_princ_password(
 
 
 @principal_router.put(
-    "", status_code=status.HTTP_202_ACCEPTED,
+    "",
+    status_code=status.HTTP_202_ACCEPTED,
     response_class=Response,
 )
 async def rename_princ(

--- a/app/alembic/env.py
+++ b/app/alembic/env.py
@@ -9,8 +9,6 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from config import Settings
 from models import Base
 
-# this is the Alembic Config object, which provides
-# access to the values within the .ini file in use.
 config = context.config
 
 # Interpret the config file for Python logging.

--- a/app/alembic/env.py
+++ b/app/alembic/env.py
@@ -50,7 +50,8 @@ def run_migrations_online():
     """
     conn = context.config.attributes.get("connection", None)
     settings = context.config.attributes.get(
-        "app_settings", Settings.from_os())
+        "app_settings", Settings.from_os()
+    )
 
     if conn is None:
         asyncio.run(run_async_migrations(settings))

--- a/app/alembic/versions/6f8fe2548893_fix_read_only.py
+++ b/app/alembic/versions/6f8fe2548893_fix_read_only.py
@@ -13,8 +13,8 @@ from ldap_protocol.utils.helpers import create_integer_hash
 from models import Attribute, Directory
 
 # revision identifiers, used by Alembic.
-revision = '6f8fe2548893'
-down_revision = 'fafc3d0b11ec'
+revision = "6f8fe2548893"
+down_revision = "fafc3d0b11ec"
 branch_labels = None
 depends_on = None
 
@@ -25,34 +25,34 @@ def upgrade() -> None:
     session = Session(bind=bind)
 
     ro_dir = session.scalar(select(Directory).where(
-        Directory.name == 'readonly domain controllers'))
+        Directory.name == "readonly domain controllers"))
 
     if not ro_dir:
         return
 
     session.execute(delete(Attribute).where(
-        Attribute.name == 'objectSid', Attribute.directory == ro_dir))
+        Attribute.name == "objectSid", Attribute.directory == ro_dir))
     session.execute(
         update(Attribute)
         .where(
-            Attribute.name == 'sAMAccountName',
+            Attribute.name == "sAMAccountName",
             Attribute.directory == ro_dir,
-            Attribute.value == 'domain users',
+            Attribute.value == "domain users",
         )
-        .values({'value': ro_dir.name}),
+        .values({"value": ro_dir.name}),
     )
 
     attr_object_class = session.scalar(
         select(Attribute)
         .where(
-            Attribute.name == 'objectClass',
+            Attribute.name == "objectClass",
             Attribute.directory == ro_dir,
-            Attribute.value == 'group',
+            Attribute.value == "group",
         ),
     )
     if not attr_object_class:
         session.add(Attribute(
-            name='objectClass', value='group', directory=ro_dir))
+            name="objectClass", value="group", directory=ro_dir))
         session.add(Attribute(
             name=ro_dir.rdname,
             value=ro_dir.name,
@@ -60,14 +60,14 @@ def upgrade() -> None:
             ),
         )
         session.add(Attribute(
-            name='gidNumber',
+            name="gidNumber",
             value=str(create_integer_hash(ro_dir.name)),
             directory=ro_dir,
             ),
         )
 
-    domain_sid = '-'.join(ro_dir.object_sid.split('-')[:-1])
-    ro_dir.object_sid = domain_sid + '-521'
+    domain_sid = "-".join(ro_dir.object_sid.split("-")[:-1])
+    ro_dir.object_sid = domain_sid + "-521"
 
     session.commit()
 

--- a/app/alembic/versions/6f8fe2548893_fix_read_only.py
+++ b/app/alembic/versions/6f8fe2548893_fix_read_only.py
@@ -25,14 +25,20 @@ def upgrade() -> None:
     bind = op.get_bind()
     session = Session(bind=bind)
 
-    ro_dir = session.scalar(select(Directory).where(
-        Directory.name == "readonly domain controllers"))
+    ro_dir = session.scalar(
+        select(Directory).where(
+            Directory.name == "readonly domain controllers"
+        )
+    )
 
     if not ro_dir:
         return
 
-    session.execute(delete(Attribute).where(
-        Attribute.name == "objectSid", Attribute.directory == ro_dir))
+    session.execute(
+        delete(Attribute).where(
+            Attribute.name == "objectSid", Attribute.directory == ro_dir
+        )
+    )
     session.execute(
         update(Attribute)
         .where(
@@ -44,26 +50,28 @@ def upgrade() -> None:
     )
 
     attr_object_class = session.scalar(
-        select(Attribute)
-        .where(
+        select(Attribute).where(
             Attribute.name == "objectClass",
             Attribute.directory == ro_dir,
             Attribute.value == "group",
         ),
     )
     if not attr_object_class:
-        session.add(Attribute(
-            name="objectClass", value="group", directory=ro_dir))
-        session.add(Attribute(
-            name=ro_dir.rdname,
-            value=ro_dir.name,
-            directory=ro_dir,
+        session.add(
+            Attribute(name="objectClass", value="group", directory=ro_dir)
+        )
+        session.add(
+            Attribute(
+                name=ro_dir.rdname,
+                value=ro_dir.name,
+                directory=ro_dir,
             ),
         )
-        session.add(Attribute(
-            name="gidNumber",
-            value=str(create_integer_hash(ro_dir.name)),
-            directory=ro_dir,
+        session.add(
+            Attribute(
+                name="gidNumber",
+                value=str(create_integer_hash(ro_dir.name)),
+                directory=ro_dir,
             ),
         )
 

--- a/app/alembic/versions/6f8fe2548893_fix_read_only.py
+++ b/app/alembic/versions/6f8fe2548893_fix_read_only.py
@@ -5,6 +5,7 @@ Revises: fafc3d0b11ec
 Create Date: 2024-11-14 13:02:33.899640
 
 """
+
 from alembic import op
 from sqlalchemy import delete, select, update
 from sqlalchemy.orm import Session

--- a/app/alembic/versions/8c2bd40dd809_add_protocols_attr.py
+++ b/app/alembic/versions/8c2bd40dd809_add_protocols_attr.py
@@ -9,8 +9,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = '8c2bd40dd809'
-down_revision = '6f8fe2548893'
+revision = "8c2bd40dd809"
+down_revision = "6f8fe2548893"
 branch_labels = None
 depends_on = None
 
@@ -19,11 +19,11 @@ def upgrade() -> None:
     """Upgrade."""
     for protocol_field in ("is_http", "is_ldap", "is_kerberos"):
         op.add_column(
-            'Policies',
+            "Policies",
             sa.Column(
                 protocol_field,
                 sa.Boolean(),
-                server_default=sa.text('true'),
+                server_default=sa.text("true"),
                 nullable=False,
             ),
         )
@@ -32,4 +32,4 @@ def upgrade() -> None:
 def downgrade() -> None:
     """Downgrade."""
     for protocol_field in ("is_http", "is_ldap", "is_kerberos"):
-        op.drop_column('Policies', protocol_field)
+        op.drop_column("Policies", protocol_field)

--- a/app/alembic/versions/8c2bd40dd809_add_protocols_attr.py
+++ b/app/alembic/versions/8c2bd40dd809_add_protocols_attr.py
@@ -5,6 +5,7 @@ Revises: 6f8fe2548893
 Create Date: 2024-12-04 16:24:35.521868
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/app/alembic/versions/bf435bbd95ff_add_rdn_attr_name.py
+++ b/app/alembic/versions/bf435bbd95ff_add_rdn_attr_name.py
@@ -12,15 +12,15 @@ from sqlalchemy.orm import Session
 from models import Attribute, Directory
 
 # revision identifiers, used by Alembic.
-revision = 'bf435bbd95ff'
-down_revision = '196f0d327c6a'
+revision = "bf435bbd95ff"
+down_revision = "196f0d327c6a"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
     """Upgrade."""
-    op.add_column('Directory', sa.Column('rdname', sa.String(length=64)))
+    op.add_column("Directory", sa.Column("rdname", sa.String(length=64)))
 
     bind = op.get_bind()
     session = Session(bind=bind)
@@ -29,13 +29,13 @@ def upgrade() -> None:
 
     for directory in session.query(Directory):
         if directory.is_domain:
-            directory.rdname = ''
+            directory.rdname = ""
             continue
 
-        rdname = directory.path[-1].split('=')[0]
+        rdname = directory.path[-1].split("=")[0]
         directory.rdname = rdname
 
-        if rdname == 'krbprincipalname':
+        if rdname == "krbprincipalname":
             continue  # already exists
 
         attrs.append(Attribute(
@@ -47,7 +47,7 @@ def upgrade() -> None:
     session.add_all(attrs)
     session.commit()
 
-    op.alter_column('Directory', 'rdname', nullable=False)
+    op.alter_column("Directory", "rdname", nullable=False)
 
 
 def downgrade() -> None:
@@ -57,16 +57,16 @@ def downgrade() -> None:
 
     for directory in session.query(Directory):
         if directory.is_domain:
-            directory.rdname = ''
+            directory.rdname = ""
             continue
 
         session.execute(
             sa.delete(Attribute)
             .where(
                 Attribute.name == directory.rdname,
-                Attribute.name != 'krbprincipalname',
+                Attribute.name != "krbprincipalname",
                 Attribute.directory_id == directory.id,
             ),
         )
 
-    op.drop_column('Directory', 'rdname')
+    op.drop_column("Directory", "rdname")

--- a/app/alembic/versions/bf435bbd95ff_add_rdn_attr_name.py
+++ b/app/alembic/versions/bf435bbd95ff_add_rdn_attr_name.py
@@ -5,6 +5,7 @@ Revises: 196f0d327c6a
 Create Date: 2024-10-23 10:46:24.419163
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.orm import Session

--- a/app/alembic/versions/bf435bbd95ff_add_rdn_attr_name.py
+++ b/app/alembic/versions/bf435bbd95ff_add_rdn_attr_name.py
@@ -39,11 +39,13 @@ def upgrade() -> None:
         if rdname == "krbprincipalname":
             continue  # already exists
 
-        attrs.append(Attribute(
-            name=rdname,
-            value=directory.name,
-            directory_id=directory.id,
-        ))
+        attrs.append(
+            Attribute(
+                name=rdname,
+                value=directory.name,
+                directory_id=directory.id,
+            )
+        )
 
     session.add_all(attrs)
     session.commit()
@@ -62,8 +64,7 @@ def downgrade() -> None:
             continue
 
         session.execute(
-            sa.delete(Attribute)
-            .where(
+            sa.delete(Attribute).where(
                 Attribute.name == directory.rdname,
                 Attribute.name != "krbprincipalname",
                 Attribute.directory_id == directory.id,

--- a/app/alembic/versions/bv546ccd35fa_fix_krbadmin_attrs.py
+++ b/app/alembic/versions/bv546ccd35fa_fix_krbadmin_attrs.py
@@ -5,6 +5,7 @@ Revises: 8c2bd40dd809
 Create Date: 2024-12-10 10:46:24.419163
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.orm import Session

--- a/app/alembic/versions/bv546ccd35fa_fix_krbadmin_attrs.py
+++ b/app/alembic/versions/bv546ccd35fa_fix_krbadmin_attrs.py
@@ -38,17 +38,18 @@ def upgrade() -> None:
             "homeDirectory": "/home/krbadmin",
         }.items():
             session.execute(
-                sa.delete(Attribute)
-                .where(
+                sa.delete(Attribute).where(
                     Attribute.name == attr,
                     Attribute.directory_id == krb_admin_user.id,
                 ),
             )
-            session.add(Attribute(
-                name=attr,
-                value=new_value,
-                directory_id=krb_admin_user.id,
-            ))
+            session.add(
+                Attribute(
+                    name=attr,
+                    value=new_value,
+                    directory_id=krb_admin_user.id,
+                )
+            )
 
         krb_admin_group = session.scalar(
             sa.select(Directory)
@@ -57,17 +58,18 @@ def upgrade() -> None:
         )
 
         session.execute(
-            sa.delete(Attribute)
-            .where(
+            sa.delete(Attribute).where(
                 Attribute.name == "gidNumber",
                 Attribute.directory_id == krb_admin_group.id,
             ),
         )
-        session.add(Attribute(
-            name="gidNumber",
-            value="800",
-            directory_id=krb_admin_group.id,
-        ))
+        session.add(
+            Attribute(
+                name="gidNumber",
+                value="800",
+                directory_id=krb_admin_group.id,
+            )
+        )
 
     session.commit()
 

--- a/app/alembic/versions/bv546ccd35fa_fix_krbadmin_attrs.py
+++ b/app/alembic/versions/bv546ccd35fa_fix_krbadmin_attrs.py
@@ -12,8 +12,8 @@ from sqlalchemy.orm import Session
 from models import Attribute, Directory
 
 # revision identifiers, used by Alembic.
-revision = 'bv546ccd35fa'
-down_revision = '8c2bd40dd809'
+revision = "bv546ccd35fa"
+down_revision = "8c2bd40dd809"
 branch_labels = None
 depends_on = None
 
@@ -26,7 +26,7 @@ def upgrade() -> None:
     krb_admin_user = session.scalar(
         sa.select(Directory)
         .join(Directory.user)
-        .filter(Directory.name == 'krbadmin'),
+        .filter(Directory.name == "krbadmin"),
     )
 
     if krb_admin_user:
@@ -52,19 +52,19 @@ def upgrade() -> None:
         krb_admin_group = session.scalar(
             sa.select(Directory)
             .join(Directory.group)
-            .filter(Directory.name == 'krbadmin'),
+            .filter(Directory.name == "krbadmin"),
         )
 
         session.execute(
             sa.delete(Attribute)
             .where(
-                Attribute.name == 'gidNumber',
+                Attribute.name == "gidNumber",
                 Attribute.directory_id == krb_admin_group.id,
             ),
         )
         session.add(Attribute(
-            name='gidNumber',
-            value='800',
+            name="gidNumber",
+            value="800",
             directory_id=krb_admin_group.id,
         ))
 

--- a/app/alembic/versions/dafg3a4b22ab_add_preauth_princ.py
+++ b/app/alembic/versions/dafg3a4b22ab_add_preauth_princ.py
@@ -13,8 +13,8 @@ from ldap_protocol.kerberos import KERBEROS_STATE_NAME
 from models import Attribute, CatalogueSetting, User
 
 # revision identifiers, used by Alembic.
-revision = 'dafg3a4b22ab'
-down_revision = 'f68a134a3685'
+revision = "dafg3a4b22ab"
+down_revision = "f68a134a3685"
 branch_labels = None
 depends_on = None
 
@@ -25,23 +25,23 @@ def upgrade() -> None:
     session = Session(bind=bind)
 
     for user in session.query(User):
-        if user.sam_accout_name == 'krbadmin':
+        if user.sam_accout_name == "krbadmin":
             continue
 
-        username, domain = user.user_principal_name.split('@')
+        username, domain = user.user_principal_name.split("@")
         principal = f"{username}@{domain.upper()}"
 
         attr_principal = session.scalar(
             sa.select(Attribute)
             .filter(
-                Attribute.name == 'krbprincipalname',
+                Attribute.name == "krbprincipalname",
                 Attribute.value == principal,
             ),
         )
         if attr_principal:
             session.add(Attribute(
-                name='krbticketflags',
-                value='128',
+                name="krbticketflags",
+                value="128",
                 directory_id=attr_principal.directory_id,
             ))
 

--- a/app/alembic/versions/dafg3a4b22ab_add_preauth_princ.py
+++ b/app/alembic/versions/dafg3a4b22ab_add_preauth_princ.py
@@ -5,6 +5,7 @@ Revises: f68a134a3685
 Create Date: 2024-12-20 16:28:24.419163
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.orm import Session

--- a/app/alembic/versions/dafg3a4b22ab_add_preauth_princ.py
+++ b/app/alembic/versions/dafg3a4b22ab_add_preauth_princ.py
@@ -33,29 +33,30 @@ def upgrade() -> None:
         principal = f"{username}@{domain.upper()}"
 
         attr_principal = session.scalar(
-            sa.select(Attribute)
-            .filter(
+            sa.select(Attribute).filter(
                 Attribute.name == "krbprincipalname",
                 Attribute.value == principal,
             ),
         )
         if attr_principal:
-            session.add(Attribute(
-                name="krbticketflags",
-                value="128",
-                directory_id=attr_principal.directory_id,
-            ))
+            session.add(
+                Attribute(
+                    name="krbticketflags",
+                    value="128",
+                    directory_id=attr_principal.directory_id,
+                )
+            )
 
     # NOTE: Remove duplicate Kerberos state settings and keep the latest one
     settings = session.scalar(
-        sa.select(CatalogueSetting)
-        .where(CatalogueSetting.name == KERBEROS_STATE_NAME),
+        sa.select(CatalogueSetting).where(
+            CatalogueSetting.name == KERBEROS_STATE_NAME
+        ),
     )
 
     if settings:
         session.execute(
-            sa.delete(CatalogueSetting)
-            .where(
+            sa.delete(CatalogueSetting).where(
                 CatalogueSetting.name == KERBEROS_STATE_NAME,
                 CatalogueSetting.id != settings.id,
             ),

--- a/app/alembic/versions/f68a134a3685_add_bypass.py
+++ b/app/alembic/versions/f68a134a3685_add_bypass.py
@@ -9,8 +9,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = 'f68a134a3685'
-down_revision = 'bv546ccd35fa'
+revision = "f68a134a3685"
+down_revision = "bv546ccd35fa"
 branch_labels = None
 depends_on = None
 
@@ -18,20 +18,20 @@ depends_on = None
 def upgrade() -> None:
     """Upgrade."""
     op.add_column(
-        'Policies',
+        "Policies",
         sa.Column(
-            'bypass_no_connection',
+            "bypass_no_connection",
             sa.Boolean(),
-            server_default=sa.text('false'),
+            server_default=sa.text("false"),
             nullable=False,
         ),
     )
     op.add_column(
-        'Policies',
+        "Policies",
         sa.Column(
-            'bypass_service_failure',
+            "bypass_service_failure",
             sa.Boolean(),
-            server_default=sa.text('false'),
+            server_default=sa.text("false"),
             nullable=False,
         ),
     )
@@ -39,5 +39,5 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """Downgrade."""
-    op.drop_column('Policies', 'bypass_service_failure')
-    op.drop_column('Policies', 'bypass_no_connection')
+    op.drop_column("Policies", "bypass_service_failure")
+    op.drop_column("Policies", "bypass_no_connection")

--- a/app/alembic/versions/f68a134a3685_add_bypass.py
+++ b/app/alembic/versions/f68a134a3685_add_bypass.py
@@ -5,6 +5,7 @@ Revises: bv546ccd35fa
 Create Date: 2024-12-18 14:52:13.992686
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/app/alembic/versions/fafc3d0b11ec_.py
+++ b/app/alembic/versions/fafc3d0b11ec_.py
@@ -5,6 +5,7 @@ Revises: bf435bbd95ff
 Create Date: 2024-11-11 15:21:23.568233
 
 """
+
 from alembic import op
 from sqlalchemy import delete, exists, select
 from sqlalchemy.exc import DBAPIError, IntegrityError

--- a/app/alembic/versions/fafc3d0b11ec_.py
+++ b/app/alembic/versions/fafc3d0b11ec_.py
@@ -19,8 +19,8 @@ from ldap_protocol.utils.queries import (
 from models import AccessPolicy, Directory
 
 # revision identifiers, used by Alembic.
-revision = 'fafc3d0b11ec'
-down_revision = 'bf435bbd95ff'
+revision = "fafc3d0b11ec"
+down_revision = "bf435bbd95ff"
 branch_labels = None
 depends_on = None
 
@@ -38,12 +38,12 @@ def upgrade() -> None:
             group_dir = (await session.scalars(
                 select(
                     exists(Directory)
-                    .where(Directory.name == 'readonly domain controllers')),
+                    .where(Directory.name == "readonly domain controllers")),
             )).one()
 
             if not group_dir:
                 dir_, _ = await create_group(
-                    'readonly domain controllers', 521, session)
+                    "readonly domain controllers", 521, session)
 
             await session.flush()
         except (IntegrityError, DBAPIError):
@@ -52,12 +52,12 @@ def upgrade() -> None:
         has_ro_access_policy = (await session.scalars(
             select(
                 exists(AccessPolicy)
-                .where(AccessPolicy.name == 'ReadOnly Access Policy')),
+                .where(AccessPolicy.name == "ReadOnly Access Policy")),
         )).one()
 
         if not has_ro_access_policy:
             await create_access_policy(
-                name='ReadOnly Access Policy',
+                name="ReadOnly Access Policy",
                 can_add=False,
                 can_modify=False,
                 can_read=True,
@@ -87,7 +87,7 @@ def downgrade() -> None:
 
         await session.execute(
             delete(AccessPolicy)
-            .where(AccessPolicy.name == 'ReadOnly Access Policy'),
+            .where(AccessPolicy.name == "ReadOnly Access Policy"),
         )
 
         await session.execute(

--- a/app/api/auth/oauth2.py
+++ b/app/api/auth/oauth2.py
@@ -86,9 +86,9 @@ async def get_current_user(
 
     user = await session.scalar(
         select(User)
-        .options(
-            defaultload(User.groups).selectinload(Group.access_policies))
-        .where(User.id == user_id))
+        .options(defaultload(User.groups).selectinload(Group.access_policies))
+        .where(User.id == user_id)
+    )
 
     if user is None:
         raise _CREDENTIALS_EXCEPTION
@@ -96,7 +96,8 @@ async def get_current_user(
     session_id, _ = session_key.split(".")
     try:
         if await session_storage.check_rekey(
-            session_id, settings.SESSION_REKEY_INTERVAL,
+            session_id,
+            settings.SESSION_REKEY_INTERVAL,
         ):
             key = await session_storage.rekey_session(session_id, settings)
             response.set_cookie(

--- a/app/api/auth/oauth2.py
+++ b/app/api/auth/oauth2.py
@@ -52,7 +52,7 @@ async def authenticate_user(
 
 
 @inject
-async def get_current_user(  # noqa: D103
+async def get_current_user(
     settings: FromDishka[Settings],
     session: FromDishka[AsyncSession],
     session_storage: FromDishka[SessionStorage],

--- a/app/api/auth/oauth2.py
+++ b/app/api/auth/oauth2.py
@@ -3,6 +3,7 @@
 Copyright (c) 2024 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
+
 from ipaddress import IPv4Address, IPv6Address
 from typing import Annotated
 
@@ -79,7 +80,10 @@ async def get_current_user(
     session_key = request.cookies.get("id", "")
     try:
         user_id = await session_storage.get_user_id(
-            settings, session_key, user_agent, str(ip),
+            settings,
+            session_key,
+            user_agent,
+            str(ip),
         )
     except KeyError as err:
         raise _CREDENTIALS_EXCEPTION from err

--- a/app/api/auth/router.py
+++ b/app/api/auth/router.py
@@ -97,7 +97,8 @@ async def login(
         .join(Group.users)
         .join(Group.directory)
         .filter(User.id == user.id, Directory.name == "domain admins")
-        .exists())
+        .exists()
+    )
 
     is_part_of_admin_group = (await session.scalars(select(query))).one()
 
@@ -121,10 +122,11 @@ async def login(
         raise HTTPException(status.HTTP_403_FORBIDDEN)
 
     if mfa and network_policy.mfa_status in (
-        MFAFlags.ENABLED, MFAFlags.WHITELIST,
+        MFAFlags.ENABLED,
+        MFAFlags.WHITELIST,
     ):
         request_2fa = True
-        if (network_policy.mfa_status == MFAFlags.WHITELIST):
+        if network_policy.mfa_status == MFAFlags.WHITELIST:
             request_2fa = await check_mfa_group(network_policy, user, session)
 
         if request_2fa:
@@ -134,8 +136,13 @@ async def login(
             )
 
     await create_and_set_session_key(
-        user, session, settings,
-        response, storage, ip, user_agent,
+        user,
+        session,
+        settings,
+        response,
+        storage,
+        ip,
+        user_agent,
     )
 
 
@@ -338,7 +345,8 @@ async def first_setup(
 
             default_pwd_policy = PasswordPolicySchema()
             errors = await default_pwd_policy.validate_password_with_policy(
-                request.password, None,
+                request.password,
+                None,
             )
 
             if errors:
@@ -349,9 +357,11 @@ async def first_setup(
 
             await default_pwd_policy.create_policy_settings(session, kadmin)
 
-            domain = (await session.scalars(
-                select(Directory).filter(Directory.parent_id.is_(None)),
-            )).one()
+            domain = (
+                await session.scalars(
+                    select(Directory).filter(Directory.parent_id.is_(None)),
+                )
+            ).one()
 
             await create_access_policy(
                 name="Root Access Policy",
@@ -372,8 +382,8 @@ async def first_setup(
                 can_delete=False,
                 grant_dn=domain.path_dn,
                 groups=[
-                    "cn=readonly domain controllers,cn=groups," +
-                    domain.path_dn,
+                    "cn=readonly domain controllers,cn=groups,"
+                    + domain.path_dn,
                 ],
                 session=session,
             )

--- a/app/api/auth/router.py
+++ b/app/api/auth/router.py
@@ -82,7 +82,7 @@ async def login(
     :raises HTTPException: 403 if user not part of network policy
     :raises HTTPException: 426 if mfa required
     :return None: None
-    """  # noqa: D205, D301
+    """
     user = await authenticate_user(session, form.username, form.password)
 
     if not user:
@@ -92,7 +92,7 @@ async def login(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    query = (  # noqa: ECE001
+    query = (
         select(Group)
         .join(Group.users)
         .join(Group.directory)
@@ -244,7 +244,7 @@ async def first_setup(
     if setup_already_performed:
         raise HTTPException(status.HTTP_423_LOCKED)
 
-    data = [  # noqa
+    data = [
         {
             "name": "groups",
             "object_class": "container",

--- a/app/api/auth/router.py
+++ b/app/api/auth/router.py
@@ -60,7 +60,7 @@ async def login(
     ip: Annotated[IPv4Address | IPv6Address, Depends(get_ip_from_request)],
     user_agent: Annotated[str, Depends(get_user_agent_from_request)],
 ) -> None:
-    """Create session to cookies and storage.
+    r"""Create session to cookies and storage.
 
     - **username**: username formats:
     `DN`, `userPrincipalName`, `saMAccountName`
@@ -169,7 +169,7 @@ async def password_reset(
     session: FromDishka[AsyncSession],
     kadmin: FromDishka[AbstractKadmin],
 ) -> None:
-    """Reset user's (entry) password.
+    r"""Reset user's (entry) password.
 
     - **identity**: user identity, any
     `userPrincipalName`, `saMAccountName` or `DN`

--- a/app/api/auth/router_mfa.py
+++ b/app/api/auth/router_mfa.py
@@ -61,11 +61,11 @@ async def setup_mfa(
     mfa: MFACreateRequest,
     session: FromDishka[AsyncSession],
 ) -> bool:
-    """Set mfa credentials, rewrites if exists.
+    r"""Set mfa credentials, rewrites if exists.
     \f
     :param MFACreateRequest mfa: MuliFactor credentials
     :param FromDishka[AsyncSession] session: db
-    :return bool: status
+    :return bool: status.
     """
     async with session.begin_nested():
         await session.execute(
@@ -111,9 +111,9 @@ async def get_mfa(
     mfa_creds: FromDishka[MFA_HTTP_Creds],
     mfa_creds_ldap: FromDishka[MFA_LDAP_Creds],
 ) -> MFAGetResponse:
-    """Get MFA creds.
+    r"""Get MFA creds.
     \f
-    :return MFAGetResponse: response
+    :return MFAGetResponse: response.
     """
     if not mfa_creds:
         mfa_creds = MFA_HTTP_Creds(Creds(None, None))
@@ -139,7 +139,7 @@ async def callback_mfa(
     ip: Annotated[IPv4Address | IPv6Address, Depends(get_ip_from_request)],
     user_agent: Annotated[str, Depends(get_user_agent_from_request)],
 ) -> RedirectResponse:
-    """Disassemble mfa token and send redirect.
+    r"""Disassemble mfa token and send redirect.
 
     Callback endpoint for MFA.
     \f
@@ -190,7 +190,7 @@ async def two_factor_protocol(
     ip: Annotated[IPv4Address | IPv6Address, Depends(get_ip_from_request)],
     user_agent: Annotated[str, Depends(get_user_agent_from_request)],
 ) -> MFAChallengeResponse:
-    """Initiate two factor protocol with app.
+    r"""Initiate two factor protocol with app.
     \f
     :param Annotated[OAuth2Form, Depends form: password form
     :param Request request: FastAPI request
@@ -205,7 +205,7 @@ async def two_factor_protocol(
     :raises HTTPException: network policy violation
     :raises HTTPException: Multifactor error
     :return MFAChallengeResponse:
-        {'status': 'pending', 'message': https://example.com}
+        {'status': 'pending', 'message': https://example.com}.
     """
     if not api:
         raise HTTPException(

--- a/app/api/auth/router_mfa.py
+++ b/app/api/auth/router_mfa.py
@@ -35,8 +35,7 @@ from ldap_protocol.multifactor import (
 )
 from ldap_protocol.policies.network_policy import get_user_network_policy
 from ldap_protocol.session_storage import SessionStorage
-from models import CatalogueSetting
-from models import User as DBUser
+from models import CatalogueSetting, User as DBUser
 
 from .oauth2 import ALGORITHM, authenticate_user
 from .schema import (
@@ -67,7 +66,7 @@ async def setup_mfa(
     :param MFACreateRequest mfa: MuliFactor credentials
     :param FromDishka[AsyncSession] session: db
     :return bool: status
-    """  # noqa: D301
+    """
     async with session.begin_nested():
         await session.execute(
             (
@@ -95,7 +94,7 @@ async def remove_mfa(
     scope: Literal["ldap", "http"],
 ) -> None:
     """Remove mfa credentials."""
-    if scope == 'http':
+    if scope == "http":
         keys = ["mfa_key", "mfa_secret"]
     else:
         keys = ["mfa_key_ldap", "mfa_secret_ldap"]
@@ -115,7 +114,7 @@ async def get_mfa(
     """Get MFA creds.
     \f
     :return MFAGetResponse: response
-    """  # noqa: D301
+    """
     if not mfa_creds:
         mfa_creds = MFA_HTTP_Creds(Creds(None, None))
     if not mfa_creds_ldap:
@@ -153,7 +152,7 @@ async def callback_mfa(
     :param Annotated[str, Form access_token: token from multifactor callback
     :raises HTTPException: if mfa not set up
     :return RedirectResponse: on bypass or success
-    """  # noqa: D301
+    """
     if not mfa_creds:
         raise HTTPException(status.HTTP_404_NOT_FOUND)
 

--- a/app/api/auth/router_mfa.py
+++ b/app/api/auth/router_mfa.py
@@ -100,8 +100,7 @@ async def remove_mfa(
         keys = ["mfa_key_ldap", "mfa_secret_ldap"]
 
     await session.execute(
-        delete(CatalogueSetting)
-        .filter(CatalogueSetting.name.in_(keys)),
+        delete(CatalogueSetting).filter(CatalogueSetting.name.in_(keys)),
     )
     await session.commit()
 
@@ -130,8 +129,9 @@ async def get_mfa(
 
 @mfa_router.post("/create", name="callback_mfa", include_in_schema=True)
 async def callback_mfa(
-    access_token: Annotated[str, Form(
-        alias="accessToken", validation_alias="accessToken")],
+    access_token: Annotated[
+        str, Form(alias="accessToken", validation_alias="accessToken")
+    ],
     session: FromDishka[AsyncSession],
     storage: FromDishka[SessionStorage],
     settings: FromDishka[Settings],
@@ -174,7 +174,8 @@ async def callback_mfa(
 
     response = RedirectResponse("/", status.HTTP_302_FOUND)
     await create_and_set_session_key(
-        user, session, settings, response, storage, ip, user_agent)
+        user, session, settings, response, storage, ip, user_agent
+    )
     return response
 
 
@@ -238,7 +239,8 @@ async def two_factor_protocol(
     except MultifactorAPI.MFAConnectError:
         if network_policy.bypass_no_connection:
             await create_and_set_session_key(
-                user, session, settings, response, storage, ip, user_agent)
+                user, session, settings, response, storage, ip, user_agent
+            )
             return MFAChallengeResponse(status="bypass", message="")
 
         logger.critical(f"API error {traceback.format_exc()}")
@@ -249,13 +251,15 @@ async def two_factor_protocol(
 
     except MultifactorAPI.MFAMissconfiguredError:
         await create_and_set_session_key(
-            user, session, settings, response, storage, ip, user_agent)
+            user, session, settings, response, storage, ip, user_agent
+        )
         return MFAChallengeResponse(status="bypass", message="")
 
     except MultifactorAPI.MultifactorError:
         if network_policy.bypass_service_failure:
             await create_and_set_session_key(
-                user, session, settings, response, storage, ip, user_agent)
+                user, session, settings, response, storage, ip, user_agent
+            )
             return MFAChallengeResponse(status="bypass", message="")
 
         logger.critical(f"API error {traceback.format_exc()}")

--- a/app/api/auth/schema.py
+++ b/app/api/auth/schema.py
@@ -37,10 +37,10 @@ class Login(BaseModel):
 class OAuth2Form(OAuth2PasswordRequestForm):
     """OAuth2 custom form."""
 
-    def __init__(  # noqa: D107
+    def __init__(
         self,
-        username: str = Form(),  # noqa: B008
-        password: str = Form(),  # noqa: B008
+        username: str = Form(),
+        password: str = Form(),
     ):
         self.username = username
         self.password = password
@@ -51,7 +51,7 @@ class Token(BaseModel):
 
     access_token: str
     refresh_token: str
-    type: str  # noqa: A003
+    type: str
 
 
 class SetupRequest(BaseModel):
@@ -80,7 +80,7 @@ class MFACreateRequest(BaseModel):
 
     @computed_field  # type: ignore
     @property
-    def key_name(self) -> str:  # noqa
+    def key_name(self) -> str:
         if self.is_ldap_scope:
             return "mfa_key_ldap"
 
@@ -88,7 +88,7 @@ class MFACreateRequest(BaseModel):
 
     @computed_field  # type: ignore
     @property
-    def secret_name(self) -> str:  # noqa
+    def secret_name(self) -> str:
         if self.is_ldap_scope:
             return "mfa_secret_ldap"
 
@@ -114,9 +114,9 @@ class MFAChallengeResponse(BaseModel):
 class SessionContentSchema(BaseModel):
     """Session content schema."""
 
-    model_config = ConfigDict(extra='allow')
+    model_config = ConfigDict(extra="allow")
 
-    id: int  # noqa: A003
+    id: int
     sign: str = Field("", description="Session signature")
     issued: datetime
     ip: IPv4Address | IPv6Address

--- a/app/api/auth/session_router.py
+++ b/app/api/auth/session_router.py
@@ -47,7 +47,8 @@ async def delete_user_sessions(
 
 
 @session_router.delete(
-    "/session/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
+    "/session/{session_id}", status_code=status.HTTP_204_NO_CONTENT
+)
 async def delete_session(
     session_id: str,
     storage: FromDishka[SessionStorage],

--- a/app/api/auth/utils.py
+++ b/app/api/auth/utils.py
@@ -38,8 +38,7 @@ def get_user_agent_from_request(request: Request) -> str:
     :param Request request: The incoming request object.
     :return str: The user agent header.
     """
-    user_agent_header = request.headers.get("User-Agent")
-    return "" if not user_agent_header else user_agent_header
+    return request.headers.get("User-Agent", "")
 
 
 async def create_and_set_session_key(

--- a/app/api/exception_handlers.py
+++ b/app/api/exception_handlers.py
@@ -1,4 +1,5 @@
 """Exception handlers."""
+
 from typing import NoReturn
 
 from fastapi import HTTPException, Request, status

--- a/app/api/main/ap_router.py
+++ b/app/api/main/ap_router.py
@@ -23,10 +23,10 @@ access_policy_router = APIRouter(
 async def get_access_policies(
     session: FromDishka[AsyncSession],
 ) -> list[MaterialAccessPolicySchema]:
-    """Get APs.
+    r"""Get APs.
     \f
     :param AccessPolicySchema policy: ap
-    :param FromDishka[AsyncSession] session: db
+    :param FromDishka[AsyncSession] session: db.
     """
     return [
         MaterialAccessPolicySchema(

--- a/app/api/main/ap_router.py
+++ b/app/api/main/ap_router.py
@@ -14,7 +14,8 @@ from ldap_protocol.policies.access_policy import get_policies
 from .schema import MaterialAccessPolicySchema
 
 access_policy_router = APIRouter(
-    prefix="/access_policy", tags=["Access Policy"],
+    prefix="/access_policy",
+    tags=["Access Policy"],
 )
 
 

--- a/app/api/main/dns_router.py
+++ b/app/api/main/dns_router.py
@@ -28,14 +28,14 @@ from ldap_protocol.dns import (
 )
 
 dns_router = APIRouter(
-    prefix='/dns',
-    tags=['DNS_SERVICE'],
+    prefix="/dns",
+    tags=["DNS_SERVICE"],
     dependencies=[Depends(get_current_user)],
     route_class=DishkaRoute,
 )
 
 
-@dns_router.post('/record')
+@dns_router.post("/record")
 async def create_record(
     data: DNSServiceRecordCreateRequest,
     dns_manager: FromDishka[AbstractDNSManager],
@@ -49,7 +49,7 @@ async def create_record(
     )
 
 
-@dns_router.delete('/record')
+@dns_router.delete("/record")
 async def delete_single_record(
     data: DNSServiceRecordDeleteRequest,
     dns_manager: FromDishka[AbstractDNSManager],
@@ -62,7 +62,7 @@ async def delete_single_record(
     )
 
 
-@dns_router.patch('/record')
+@dns_router.patch("/record")
 async def update_record(
     data: DNSServiceRecordUpdateRequest,
     dns_manager: FromDishka[AbstractDNSManager],
@@ -76,7 +76,7 @@ async def update_record(
     )
 
 
-@dns_router.get('/record')
+@dns_router.get("/record")
 async def get_all_records(
     dns_manager: FromDishka[AbstractDNSManager],
 ) -> list[DNSRecords]:
@@ -84,7 +84,7 @@ async def get_all_records(
     return await dns_manager.get_all_records()
 
 
-@dns_router.get('/status')
+@dns_router.get("/status")
 async def get_dns_status(
     session: FromDishka[AsyncSession],
     dns_settings: FromDishka[DNSManagerSettings],
@@ -98,7 +98,7 @@ async def get_dns_status(
     }
 
 
-@dns_router.post('/setup')
+@dns_router.post("/setup")
 async def setup_dns(
     data: DNSServiceSetupRequest,
     dns_manager: FromDishka[AbstractDNSManager],

--- a/app/api/main/dns_router.py
+++ b/app/api/main/dns_router.py
@@ -3,6 +3,7 @@
 Copyright (c) 2024 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
+
 from dishka import FromDishka
 from dishka.integrations.fastapi import DishkaRoute
 from fastapi import Depends, HTTPException

--- a/app/api/main/krb5_router.py
+++ b/app/api/main/krb5_router.py
@@ -207,22 +207,27 @@ async def setup_kdc(
         )
     except KRBAPIError as err:
         direstories = await session.scalars(
-            select(Directory)
-            .where(or_(
-                get_filter_from_path(krbadmin),
-                get_filter_from_path(services_container),
-                get_filter_from_path(krbgroup),
-            )))
+            select(Directory).where(
+                or_(
+                    get_filter_from_path(krbadmin),
+                    get_filter_from_path(services_container),
+                    get_filter_from_path(krbgroup),
+                )
+            )
+        )
 
         if direstories:
             await session.execute(
-                delete(Directory)
-                .where(Directory.id.in_(
-                    [directory.id for directory in direstories])),
+                delete(Directory).where(
+                    Directory.id.in_(
+                        [directory.id for directory in direstories]
+                    )
+                ),
             )
         await session.execute(
-            delete(AccessPolicy)
-            .where(AccessPolicy.name == KERBEROS_POLICY_NAME),
+            delete(AccessPolicy).where(
+                AccessPolicy.name == KERBEROS_POLICY_NAME
+            ),
         )
         await kadmin.reset_setup()
         raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, str(err))
@@ -304,7 +309,8 @@ async def add_principal(
 
 
 @krb5_router.patch(
-    "/principal/rename", dependencies=[Depends(get_current_user)])
+    "/principal/rename", dependencies=[Depends(get_current_user)]
+)
 async def rename_principal(
     principal_name: Annotated[LIMITED_STR, Body()],
     principal_new_name: Annotated[LIMITED_STR, Body()],
@@ -324,7 +330,8 @@ async def rename_principal(
 
 
 @krb5_router.patch(
-    "/principal/reset", dependencies=[Depends(get_current_user)])
+    "/principal/reset", dependencies=[Depends(get_current_user)]
+)
 async def reset_principal_pw(
     principal_name: Annotated[LIMITED_STR, Body()],
     new_password: Annotated[LIMITED_STR, Body()],
@@ -344,7 +351,8 @@ async def reset_principal_pw(
 
 
 @krb5_router.delete(
-    "/principal/delete", dependencies=[Depends(get_current_user)])
+    "/principal/delete", dependencies=[Depends(get_current_user)]
+)
 async def delete_principal(
     principal_name: Annotated[LIMITED_STR, Body(embed=True)],
     kadmin: FromDishka[AbstractKadmin],

--- a/app/api/main/krb5_router.py
+++ b/app/api/main/krb5_router.py
@@ -152,7 +152,7 @@ async def setup_kdc(
     settings: FromDishka[Settings],
     kadmin: FromDishka[AbstractKadmin],
 ) -> None:
-    """Set up KDC server.
+    r"""Set up KDC server.
 
     Create data structure in catalogue, generate config files, trigger commands
 
@@ -291,11 +291,11 @@ async def add_principal(
     instance: Annotated[LIMITED_STR, Body()],
     kadmin: FromDishka[AbstractKadmin],
 ) -> None:
-    """Create principal in kerberos with given name.
+    r"""Create principal in kerberos with given name.
     \f
     :param Annotated[str, Body principal_name: upn
     :param Annotated[LDAPSession, Depends ldap_session: ldap
-    :raises HTTPException: on failed kamin request
+    :raises HTTPException: on failed kamin request.
     """
     try:
         await kadmin.add_principal(f"{primary}/{instance}", None)
@@ -310,12 +310,12 @@ async def rename_principal(
     principal_new_name: Annotated[LIMITED_STR, Body()],
     kadmin: FromDishka[AbstractKadmin],
 ) -> None:
-    """Rename principal in kerberos with given name.
+    r"""Rename principal in kerberos with given name.
     \f
     :param Annotated[str, Body principal_name: upn
     :param Annotated[LIMITED_STR, Body principal_new_name: _description_
     :param Annotated[LDAPSession, Depends ldap_session: ldap
-    :raises HTTPException: on failed kamin request
+    :raises HTTPException: on failed kamin request.
     """
     try:
         await kadmin.rename_princ(principal_name, principal_new_name)
@@ -330,12 +330,12 @@ async def reset_principal_pw(
     new_password: Annotated[LIMITED_STR, Body()],
     kadmin: FromDishka[AbstractKadmin],
 ) -> None:
-    """Reset principal password in kerberos with given name.
+    r"""Reset principal password in kerberos with given name.
     \f
     :param Annotated[str, Body principal_name: upn
     :param Annotated[LIMITED_STR, Body new_password: _description_
     :param Annotated[LDAPSession, Depends ldap_session: ldap
-    :raises HTTPException: on failed kamin request
+    :raises HTTPException: on failed kamin request.
     """
     try:
         await kadmin.change_principal_password(principal_name, new_password)
@@ -349,11 +349,11 @@ async def delete_principal(
     principal_name: Annotated[LIMITED_STR, Body(embed=True)],
     kadmin: FromDishka[AbstractKadmin],
 ) -> None:
-    """Delete principal in kerberos with given name.
+    r"""Delete principal in kerberos with given name.
     \f
     :param Annotated[str, Body principal_name: upn
     :param FromDishka[AbstractKadmin] kadmin: _description_
-    :raises HTTPException: on failed kamin request
+    :raises HTTPException: on failed kamin request.
     """
     try:
         await kadmin.del_principal(principal_name)

--- a/app/api/main/schema.py
+++ b/app/api/main/schema.py
@@ -3,6 +3,7 @@
 Copyright (c) 2024 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
+
 from typing import Optional, final
 
 from dishka import AsyncContainer
@@ -18,8 +19,7 @@ from ldap_protocol.ldap_responses import SearchResultDone, SearchResultEntry
 class SearchRequest(LDAPSearchRequest):
     """Search request for web api."""
 
-    filter: str = Field(
-        ..., examples=["(objectClass=*)"])  # type: ignore
+    filter: str = Field(..., examples=["(objectClass=*)"])  # type: ignore
 
     def cast_filter(self) -> UnaryExpression | ColumnElement:
         """Cast str filter to sa sql."""

--- a/app/api/main/schema.py
+++ b/app/api/main/schema.py
@@ -18,7 +18,7 @@ from ldap_protocol.ldap_responses import SearchResultDone, SearchResultEntry
 class SearchRequest(LDAPSearchRequest):
     """Search request for web api."""
 
-    filter: str = Field(  # noqa: A003
+    filter: str = Field(
         ..., examples=["(objectClass=*)"])  # type: ignore
 
     def cast_filter(self) -> UnaryExpression | ColumnElement:
@@ -35,7 +35,7 @@ class SearchRequest(LDAPSearchRequest):
         return await self._handle_api(container)  # type: ignore
 
 
-class SearchResponse(SearchResultDone):  # noqa: D101
+class SearchResponse(SearchResultDone):
     search_result: list[SearchResultEntry]
 
 
@@ -57,7 +57,7 @@ class _PolicyFields:
 
 
 class _MaterialFields:
-    id: int  # noqa: A003
+    id: int
 
 
 class AccessPolicySchema(_PolicyFields, BaseModel):

--- a/app/api/network/router.py
+++ b/app/api/network/router.py
@@ -48,7 +48,7 @@ async def add_network_policy(
     :raises HTTPException: 422 invalid group DN
     :raises HTTPException: 422 Entry already exists
     :return PolicyResponse: Ready policy
-    """  # noqa: D205, D301
+    """
     new_policy = NetworkPolicy(
         name=policy.name,
         netmasks=policy.complete_netmasks,
@@ -110,7 +110,7 @@ async def get_list_network_policies(
 
     \f
     :return list[PolicyResponse]: all policies
-    """  # noqa: D205, D301
+    """
     groups = selectinload(NetworkPolicy.groups).selectinload(Group.directory)
     mfa_groups = (
         selectinload(NetworkPolicy.mfa_groups)
@@ -162,7 +162,7 @@ async def delete_network_policy(
     :raises HTTPException: 422 On last active policy,
         at least 1 should be in database.
     :return bool: status of delete
-    """  # noqa: D205, D301
+    """
     policy = await session.get(NetworkPolicy, policy_id, with_for_update=True)
 
     if not policy:
@@ -204,7 +204,7 @@ async def switch_network_policy(
     :raises HTTPException: 422 On last active policy,
         at least 1 should be active
     :return bool: status of update
-    """  # noqa: D205, D301
+    """
     policy = await session.get(NetworkPolicy, policy_id, with_for_update=True)
 
     if not policy:
@@ -231,7 +231,7 @@ async def update_network_policy(
     :raises HTTPException: 422 Invalid group DN
     :raises HTTPException: 422 Entry already exists
     :return PolicyResponse: Policy from database
-    """  # noqa: D205, D301
+    """
     selected_policy = await session.get(
         NetworkPolicy,
         request.id,
@@ -328,7 +328,7 @@ async def swap_network_policy(
     :param int second_policy_id: policy to swap
     :raises HTTPException: 404
     :return SwapResponse: policy new priorities
-    """  # noqa: D205, D301
+    """
     policy1 = await session.get(
         NetworkPolicy, swap.first_policy_id, with_for_update=True,
     )

--- a/app/api/network/router.py
+++ b/app/api/network/router.py
@@ -41,7 +41,7 @@ async def add_network_policy(
     policy: Policy,
     session: FromDishka[AsyncSession],
 ) -> PolicyResponse:
-    """Add policy.
+    r"""Add policy.
 
     \f
     :param Policy policy: policy to add
@@ -106,7 +106,7 @@ async def add_network_policy(
 async def get_list_network_policies(
     session: FromDishka[AsyncSession],
 ) -> list[PolicyResponse]:
-    """Get network.
+    r"""Get network.
 
     \f
     :return list[PolicyResponse]: all policies
@@ -153,7 +153,7 @@ async def delete_network_policy(
     request: Request,
     session: FromDishka[AsyncSession],
 ) -> list[PolicyResponse]:
-    """Delete policy.
+    r"""Delete policy.
 
     \f
     :param int policy_id: id
@@ -194,7 +194,7 @@ async def switch_network_policy(
     policy_id: int,
     session: FromDishka[AsyncSession],
 ) -> bool:
-    """Switch state of policy.
+    r"""Switch state of policy.
 
     - **policy_id**: int, policy to switch
     \f
@@ -223,7 +223,7 @@ async def update_network_policy(
     request: PolicyUpdate,
     session: FromDishka[AsyncSession],
 ) -> PolicyResponse:
-    """Update network policy.
+    r"""Update network policy.
 
     \f
     :param PolicyUpdate policy: update request
@@ -319,7 +319,7 @@ async def swap_network_policy(
     swap: SwapRequest,
     session: FromDishka[AsyncSession],
 ) -> SwapResponse:
-    """Swap priorities for policy.
+    r"""Swap priorities for policy.
 
     - **first_policy_id**: policy to swap
     - **second_policy_id**: policy to swap

--- a/app/api/network/router.py
+++ b/app/api/network/router.py
@@ -79,7 +79,8 @@ async def add_network_policy(
         await session.commit()
     except IntegrityError:
         raise HTTPException(
-            status.HTTP_422_UNPROCESSABLE_ENTITY, "Entry already exists",
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            "Entry already exists",
         )
 
     await session.refresh(new_policy)
@@ -112,9 +113,8 @@ async def get_list_network_policies(
     :return list[PolicyResponse]: all policies
     """
     groups = selectinload(NetworkPolicy.groups).selectinload(Group.directory)
-    mfa_groups = (
-        selectinload(NetworkPolicy.mfa_groups)
-        .selectinload(Group.directory)
+    mfa_groups = selectinload(NetworkPolicy.mfa_groups).selectinload(
+        Group.directory
     )
 
     return [
@@ -147,7 +147,8 @@ async def get_list_network_policies(
 @network_router.delete(
     "/{policy_id}",
     response_class=RedirectResponse,
-    status_code=status.HTTP_303_SEE_OTHER)
+    status_code=status.HTTP_303_SEE_OTHER,
+)
 async def delete_network_policy(
     policy_id: int,
     request: Request,
@@ -330,10 +331,14 @@ async def swap_network_policy(
     :return SwapResponse: policy new priorities
     """
     policy1 = await session.get(
-        NetworkPolicy, swap.first_policy_id, with_for_update=True,
+        NetworkPolicy,
+        swap.first_policy_id,
+        with_for_update=True,
     )
     policy2 = await session.get(
-        NetworkPolicy, swap.second_policy_id, with_for_update=True,
+        NetworkPolicy,
+        swap.second_policy_id,
+        with_for_update=True,
     )
 
     if not policy1 or not policy2:

--- a/app/api/network/schema.py
+++ b/app/api/network/schema.py
@@ -74,7 +74,8 @@ class NetmasksMixin:
     @field_serializer("netmasks")
     @classmethod
     def netmasks_serialize(
-        cls, netmasks: IPv4IntefaceListType,
+        cls,
+        netmasks: IPv4IntefaceListType,
     ) -> list[str | dict]:
         """Serialize netmasks to list.
 

--- a/app/api/network/schema.py
+++ b/app/api/network/schema.py
@@ -53,7 +53,7 @@ class NetmasksMixin:
 
     @field_validator("groups")
     @classmethod
-    def validate_group(cls, groups: list[str]) -> list[str]:  # noqa
+    def validate_group(cls, groups: list[str]) -> list[str]:
         if not groups:
             return groups
         if all(validate_entry(group) for group in groups):
@@ -63,7 +63,7 @@ class NetmasksMixin:
 
     @field_validator("mfa_groups")
     @classmethod
-    def validate_mfa_group(cls, mfa_groups: list[str]) -> list[str]:  # noqa
+    def validate_mfa_group(cls, mfa_groups: list[str]) -> list[str]:
         if not mfa_groups:
             return mfa_groups
         if all(validate_entry(group) for group in mfa_groups):
@@ -115,7 +115,7 @@ class PolicyResponse(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    id: int  # noqa
+    id: int
     name: str
     netmasks: list[IPv4Network]
     raw: list[str | dict]
@@ -134,7 +134,7 @@ class PolicyResponse(BaseModel):
 class PolicyUpdate(BaseModel, NetmasksMixin):
     """Update request."""
 
-    id: int  # noqa
+    id: int
     name: str | None = None
     netmasks: IPv4IntefaceListType | None = None  # type: ignore
     groups: list[str] | None = None

--- a/app/api/shadow/router.py
+++ b/app/api/shadow/router.py
@@ -3,6 +3,7 @@
 Copyright (c) 2024 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
+
 from ipaddress import IPv4Address
 from typing import Annotated
 

--- a/app/api/shadow/router.py
+++ b/app/api/shadow/router.py
@@ -50,9 +50,7 @@ async def proxy_request(
     if not network_policy.is_kerberos:
         raise HTTPException(status.HTTP_403_FORBIDDEN)
 
-    if not mfa:  # noqa: R505
-        return
-    elif network_policy.mfa_status == MFAFlags.DISABLED:
+    if not mfa or network_policy.mfa_status == MFAFlags.DISABLED:
         return
     elif network_policy.mfa_status in (MFAFlags.ENABLED, MFAFlags.WHITELIST):
         if (

--- a/app/config.py
+++ b/app/config.py
@@ -68,13 +68,15 @@ class Settings(BaseModel):
     @cached_property
     def POSTGRES_URI(self) -> PostgresDsn:  # noqa
         """Build postgres DSN."""
-        return PostgresDsn((
-            f"{self.POSTGRES_SCHEMA}://"
-            f"{self.POSTGRES_USER}:"
-            f"{self.POSTGRES_PASSWORD}@"
-            f"{self.POSTGRES_HOST}/"
-            f"{self.POSTGRES_DB}"
-        ))
+        return PostgresDsn(
+            (
+                f"{self.POSTGRES_SCHEMA}://"
+                f"{self.POSTGRES_USER}:"
+                f"{self.POSTGRES_PASSWORD}@"
+                f"{self.POSTGRES_HOST}/"
+                f"{self.POSTGRES_DB}"
+            )
+        )
 
     VENDOR_NAME: str = "MultiFactor"
     VENDOR_VERSION: str = Field(
@@ -101,15 +103,16 @@ class Settings(BaseModel):
     KRB5_LDAP_KEYTAB: str = "/LDAP_keytab/ldap.keytab"
 
     TEMPLATES: ClassVar[jinja2.Environment] = jinja2.Environment(
-        loader=jinja2.FileSystemLoader('extra/templates'),
-        enable_async=True, autoescape=True,
+        loader=jinja2.FileSystemLoader("extra/templates"),
+        enable_async=True,
+        autoescape=True,
     )
 
-    DNS_BIND_HOST: str = 'bind_dns'
-    DNS_TSIG_KEY: str = '/DNS_server_file/zone.key'
-    DNS_ZONE_FILE: str = '/DNS_server_file/db.zone'
-    DNS_SERVER_NAMED_CONF: str = '/DNS_server_configs/named.conf'
-    DNS_SERVER_NAMED_CONF_LOCAL: str = '/DNS_server_configs/named.conf.local'
+    DNS_BIND_HOST: str = "bind_dns"
+    DNS_TSIG_KEY: str = "/DNS_server_file/zone.key"
+    DNS_ZONE_FILE: str = "/DNS_server_file/db.zone"
+    DNS_SERVER_NAMED_CONF: str = "/DNS_server_configs/named.conf"
+    DNS_SERVER_NAMED_CONF_LOCAL: str = "/DNS_server_configs/named.conf.local"
 
     GSSAPI_MAX_OUTPUT_TOKEN_SIZE: int = 1024
 

--- a/app/extra/dev_data.py
+++ b/app/extra/dev_data.py
@@ -13,7 +13,7 @@ group_attrs = {
 }
 
 
-DATA = [  # noqa
+DATA = [
     {
         "name": "main",
         "object_class": "builtinDomain",
@@ -200,7 +200,7 @@ DATA = [  # noqa
     },
 ]
 
-TEST_DATA = [  # noqa
+TEST_DATA = [
     {
         "name": "groups",
         "object_class": "container",

--- a/app/extra/scripts/krb_pass_sync.py
+++ b/app/extra/scripts/krb_pass_sync.py
@@ -24,7 +24,7 @@ async def read_and_save_krb_pwds(session: AsyncSession) -> None:
 
     :param AsyncSession session: db
     """
-    files = [  # noqa: ECE001
+    files = [
         fp
         for f in os.listdir(_PATH)
         if os.path.isfile(fp := os.path.join(_PATH, f)) and f != _LOCK_FILE

--- a/app/extra/scripts/principal_block_user_sync.py
+++ b/app/extra/scripts/principal_block_user_sync.py
@@ -23,11 +23,11 @@ from models import Attribute, Directory, User
 
 
 async def principal_block_sync(
-    session: AsyncSession, settings: Settings,
+    session: AsyncSession,
+    settings: Settings,
 ) -> None:
     """Synchronize principal and user account blocking."""
     for user in await session.scalars(select(User)):
-
         uac_check = await get_check_uac(session, user.directory_id)
         if uac_check(UserAccountControlFlag.ACCOUNTDISABLE):
             continue
@@ -50,7 +50,8 @@ async def principal_block_sync(
             continue
 
         expiration_time = datetime.strptime(
-            krb_exp_attr.value, "%Y%m%d%H%M%SZ",
+            krb_exp_attr.value,
+            "%Y%m%d%H%M%SZ",
         ).replace(
             tzinfo=settings.TIMEZONE,
         )

--- a/app/extra/scripts/uac_sync.py
+++ b/app/extra/scripts/uac_sync.py
@@ -16,7 +16,9 @@ from models import Attribute, User
 
 
 async def disable_accounts(
-    session: AsyncSession, kadmin: AbstractKadmin, settings: Settings,
+    session: AsyncSession,
+    kadmin: AbstractKadmin,
+    settings: Settings,
 ) -> None:
     """Update userAccountControl attr.
 

--- a/app/extra/scripts/uac_sync.py
+++ b/app/extra/scripts/uac_sync.py
@@ -56,7 +56,7 @@ async def disable_accounts(
         Attribute.name == "userAccountControl",
     ]
 
-    ids = await session.scalars(  # noqa: ECE001
+    ids = await session.scalars(
         update(Attribute)
         .values(value=new_value)
         .where(*conditions)

--- a/app/extra/scripts/update_krb5_config.py
+++ b/app/extra/scripts/update_krb5_config.py
@@ -3,6 +3,7 @@
 Copyright (c) 2025 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
+
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 

--- a/app/extra/setup_dev.py
+++ b/app/extra/setup_dev.py
@@ -144,7 +144,10 @@ async def _create_dir(
 
 
 async def setup_enviroment(
-    session: AsyncSession, *, data: list, dn: str = "multifactor.dev",
+    session: AsyncSession,
+    *,
+    data: list,
+    dn: str = "multifactor.dev",
 ) -> None:
     """Create directories and users for enviroment."""
     cat_result = await session.execute(select(Directory))

--- a/app/extra/setup_dev.py
+++ b/app/extra/setup_dev.py
@@ -159,7 +159,7 @@ async def setup_enviroment(
     )
     domain.path = [f"dc={path}" for path in reversed(dn.split("."))]
     domain.depth = len(domain.path)
-    domain.rdname = ''
+    domain.rdname = ""
 
     async with session.begin_nested():
         session.add(domain)
@@ -180,5 +180,5 @@ async def setup_enviroment(
     except Exception:
         import traceback
 
-        logger.error(traceback.format_exc())  # noqa
+        logger.error(traceback.format_exc())
         raise

--- a/app/ioc.py
+++ b/app/ioc.py
@@ -82,7 +82,8 @@ class MainProvider(Provider):
 
     @provide(scope=Scope.SESSION)
     async def get_krb_class(
-        self, session_maker: async_sessionmaker[AsyncSession],
+        self,
+        session_maker: async_sessionmaker[AsyncSession],
     ) -> type[AbstractKadmin]:
         """Get kerberos type."""
         async with session_maker() as session:
@@ -129,7 +130,8 @@ class MainProvider(Provider):
 
     @provide(scope=Scope.SESSION)
     async def get_dns_mngr_class(
-        self, session_maker: async_sessionmaker[AsyncSession],
+        self,
+        session_maker: async_sessionmaker[AsyncSession],
     ) -> type[AbstractDNSManager]:
         """Get DNS manager type."""
         async with session_maker() as session:
@@ -137,7 +139,8 @@ class MainProvider(Provider):
 
     @provide(scope=Scope.REQUEST)
     async def get_dns_mngr_settings(
-        self, session_maker: async_sessionmaker[AsyncSession],
+        self,
+        session_maker: async_sessionmaker[AsyncSession],
         settings: Settings,
     ) -> DNSManagerSettings:
         """Get DNS manager's settings."""
@@ -156,7 +159,8 @@ class MainProvider(Provider):
 
     @provide(scope=Scope.APP)
     async def get_redis_for_sessions(
-            self, settings: Settings) -> AsyncIterator[SessionStorageClient]:
+        self, settings: Settings
+    ) -> AsyncIterator[SessionStorageClient]:
         """Get redis connection."""
         client = redis.Redis.from_url(str(settings.SESSION_STORAGE_URL))
 
@@ -168,14 +172,16 @@ class MainProvider(Provider):
 
     @provide(scope=Scope.APP)
     async def get_session_storage(
-        self, client: SessionStorageClient,
+        self,
+        client: SessionStorageClient,
         settings: Settings,
     ) -> SessionStorage:
         """Get session storage."""
         return RedisSessionStorage(
             client,
             settings.SESSION_KEY_LENGTH,
-            settings.SESSION_KEY_EXPIRE_SECONDS)
+            settings.SESSION_KEY_EXPIRE_SECONDS,
+        )
 
 
 class HTTPProvider(Provider):
@@ -231,7 +237,8 @@ class MFAProvider(Provider):
 
     @provide(scope=Scope.APP)
     async def get_client(
-        self, settings: Settings,
+        self,
+        settings: Settings,
     ) -> AsyncIterator[MFAHTTPClient]:
         """Get async client for DI."""
         async with httpx.AsyncClient(

--- a/app/ldap_protocol/asn1parser.py
+++ b/app/ldap_protocol/asn1parser.py
@@ -58,7 +58,8 @@ class SubstringTag(IntEnum):
 
 
 T = TypeVar(
-    "T", contravariant=True,
+    "T",
+    contravariant=True,
     bound="ASN1Row | list[ASN1Row] | str | bytes | int | float",
 )
 
@@ -134,8 +135,7 @@ class ASN1Row(Generic[T]):
         try:
             substring_tag = SubstringTag(self.tag_id)
         except ValueError:
-            raise ValueError(
-                f"Invalid tag_id ({self.tag_id}) in substring")
+            raise ValueError(f"Invalid tag_id ({self.tag_id}) in substring")
 
         return substring_tag_map[substring_tag]
 
@@ -189,7 +189,8 @@ class ASN1Row(Generic[T]):
 
                 if operator is None:
                     raise ValueError(
-                        f"Invalid tag_id ({obj.tag_id}) in context")
+                        f"Invalid tag_id ({obj.tag_id}) in context"
+                    )
 
             if isinstance(obj.value, list):
                 if len(obj.value) == 2:

--- a/app/ldap_protocol/asn1parser.py
+++ b/app/ldap_protocol/asn1parser.py
@@ -92,20 +92,20 @@ class ASN1Row(Generic[T]):
                 oid = child_value
             elif tag_value == 2:
                 attribute = (
-                    child_value.decode(errors='replace')
+                    child_value.decode(errors="replace")
                     if isinstance(child_value, bytes)
                     else child_value
                 )
             elif tag_value == 3:
                 value = (
-                    child_value.decode(errors='replace')
+                    child_value.decode(errors="replace")
                     if isinstance(child_value, bytes)
                     else child_value
                 )
             elif tag_value == 4:
                 dn_attributes = bool(child_value)
 
-        match = ''
+        match = ""
         if attribute:
             match += attribute
         if oid:
@@ -122,7 +122,7 @@ class ASN1Row(Generic[T]):
     def _handle_substring(self) -> str:
         """Process and format substring operations for LDAP."""
         value = (
-            self.value.decode(errors='replace')
+            self.value.decode(errors="replace")
             if isinstance(self.value, bytes)
             else str(self.value)
         )
@@ -135,11 +135,11 @@ class ASN1Row(Generic[T]):
             substring_tag = SubstringTag(self.tag_id)
         except ValueError:
             raise ValueError(
-                f'Invalid tag_id ({self.tag_id}) in substring')
+                f"Invalid tag_id ({self.tag_id}) in substring")
 
         return substring_tag_map[substring_tag]
 
-    def serialize(self, obj: 'ASN1Row' | T | None = None) -> str:
+    def serialize(self, obj: "ASN1Row | T | None" = None) -> str:
         """
         Serialize an ASN.1 object or list into a string.
 
@@ -150,7 +150,7 @@ class ASN1Row(Generic[T]):
         if obj is None:
             obj = self
 
-        if isinstance(obj, ASN1Row):  # noqa: R505
+        if isinstance(obj, ASN1Row):
             value = obj.value
             operator = None
 
@@ -162,7 +162,7 @@ class ASN1Row(Generic[T]):
                 TagNumbers.OR,
                 TagNumbers.NOT,
             ):
-                subfilters = ''.join(self.serialize(v) for v in value)
+                subfilters = "".join(self.serialize(v) for v in value)
 
                 if obj.tag_id == TagNumbers.AND:
                     return f"(&{subfilters})"
@@ -180,24 +180,24 @@ class ASN1Row(Generic[T]):
 
             else:
                 operator_map: dict[int, str] = {
-                    TagNumbers.EQUALITY_MATCH: '=',
-                    TagNumbers.SUBSTRING: '*=',
-                    TagNumbers.GE: '>=',
-                    TagNumbers.LE: '<=',
-                    TagNumbers.APPROX_MATCH: '~=',
+                    TagNumbers.EQUALITY_MATCH: "=",
+                    TagNumbers.SUBSTRING: "*=",
+                    TagNumbers.GE: ">=",
+                    TagNumbers.LE: "<=",
+                    TagNumbers.APPROX_MATCH: "~=",
                 }
                 operator = operator_map.get(obj.tag_id)
 
                 if operator is None:
                     raise ValueError(
-                        f'Invalid tag_id ({obj.tag_id}) in context')
+                        f"Invalid tag_id ({obj.tag_id}) in context")
 
             if isinstance(obj.value, list):
                 if len(obj.value) == 2:
                     attr = self.serialize(value[0])
                     val = value[1]
-                    if operator == '*=':
-                        operator = '='
+                    if operator == "*=":
+                        operator = "="
                         substrings = val.value[0]._handle_substring()
                         value_str = substrings
                     else:
@@ -205,20 +205,20 @@ class ASN1Row(Generic[T]):
 
                     return f"({attr}{operator}{value_str})"
 
-                return ''.join(self.serialize(v) for v in obj.value)
+                return "".join(self.serialize(v) for v in obj.value)
 
             return self.serialize(obj.value)
 
         elif isinstance(obj, list):
-            return ''.join(self.serialize(v) for v in obj)
+            return "".join(self.serialize(v) for v in obj)
 
         elif isinstance(obj, bytes):
-            return obj.decode(errors='replace')
+            return obj.decode(errors="replace")
 
         elif isinstance(obj, str):
             return obj
 
-        elif isinstance(obj, int) or isinstance(obj, float):
+        elif isinstance(obj, int | float):
             return str(obj)
 
         else:

--- a/app/ldap_protocol/asn1parser.py
+++ b/app/ldap_protocol/asn1parser.py
@@ -140,8 +140,7 @@ class ASN1Row(Generic[T]):
         return substring_tag_map[substring_tag]
 
     def serialize(self, obj: "ASN1Row | T | None" = None) -> str:
-        """
-        Serialize an ASN.1 object or list into a string.
+        """Serialize an ASN.1 object or list into a string.
 
         Recursively processes ASN.1 structures to construct a valid LDAP
         filter string based on LDAP operations such as AND, OR, and
@@ -225,8 +224,7 @@ class ASN1Row(Generic[T]):
             raise TypeError
 
     def to_ldap_filter(self) -> str:
-        """
-        Convert the ASN.1 object into an LDAP filter string.
+        """Convert the ASN.1 object into an LDAP filter string.
 
         The method recursively serializes ASN.1 rows into the LDAP filter
         format based on tag IDs and class IDs.

--- a/app/ldap_protocol/dialogue.py
+++ b/app/ldap_protocol/dialogue.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 class UserSchema:
     """User model, alias for db user."""
 
-    id: int  # noqa: A003
+    id: int
     session_id: str
     sam_accout_name: str
     user_principal_name: str

--- a/app/ldap_protocol/dialogue.py
+++ b/app/ldap_protocol/dialogue.py
@@ -3,6 +3,7 @@
 Copyright (c) 2024 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -79,7 +80,9 @@ class LDAPSession:
     gssapi_security_layer: "GSSAPISL"
 
     def __init__(
-        self, *, user: UserSchema | None = None,
+        self,
+        *,
+        user: UserSchema | None = None,
         storage: SessionStorage | None = None,
     ) -> None:
         """Set lock."""
@@ -137,7 +140,8 @@ class LDAPSession:
         return ":".join(map(str, writer.get_extra_info("peername")))
 
     async def get_ip(
-            self, writer: asyncio.StreamWriter) -> IPv4Address | IPv6Address:
+        self, writer: asyncio.StreamWriter
+    ) -> IPv4Address | IPv6Address:
         """Get ip addr from writer."""
         addr = self.get_address(writer)
         ip = ip_address(addr.split(":")[0])
@@ -146,13 +150,16 @@ class LDAPSession:
 
     @staticmethod
     async def _get_policy(
-        ip: IPv4Address, session: AsyncSession,
+        ip: IPv4Address,
+        session: AsyncSession,
     ) -> NetworkPolicy | None:
         query = build_policy_query(ip, "is_ldap")
         return await session.scalar(query)
 
     async def validate_conn(
-        self, ip: IPv4Address | IPv6Address, session: AsyncSession,
+        self,
+        ip: IPv4Address | IPv6Address,
+        session: AsyncSession,
     ) -> None:
         """Validate network policies."""
         policy = await self._get_policy(ip, session)  # type: ignore
@@ -178,7 +185,8 @@ class LDAPSession:
 
         await self.storage.delete_user_session(self.key)
         await self.storage.create_ldap_session(
-            self.user.id, self.key, {"id": self.user.id, "ip": str(self.ip)})
+            self.user.id, self.key, {"id": self.user.id, "ip": str(self.ip)}
+        )
 
     async def disconnect(self) -> None:
         """Disconnect session."""

--- a/app/ldap_protocol/dns.py
+++ b/app/ldap_protocol/dns.py
@@ -11,11 +11,9 @@ from dataclasses import dataclass
 from enum import Enum, StrEnum
 from typing import Any, Awaitable, Callable
 
-from dns.asyncquery import inbound_xfr as make_inbound_xfr
-from dns.asyncquery import tcp as asynctcp
+from dns.asyncquery import inbound_xfr as make_inbound_xfr, tcp as asynctcp
 from dns.asyncresolver import Resolver as AsyncResolver
-from dns.message import Message
-from dns.message import make_query as make_dns_query
+from dns.message import Message, make_query as make_dns_query
 from dns.name import from_text
 from dns.rdataclass import IN
 from dns.rdatatype import AXFR
@@ -35,11 +33,11 @@ DNS_MANAGER_IP_ADDRESS_NAME = "DNSManagerIpAddress"
 DNS_MANAGER_TSIG_KEY_NAME = "DNSManagerTSIGKey"
 
 
-log = loguru_logger.bind(name='DNSManager')
+log = loguru_logger.bind(name="DNSManager")
 
 log.add(
     "logs/dnsmanager_{time:DD-MM-YYYY}.log",
-    filter=lambda rec: rec["extra"].get("name") == 'dnsmanager',
+    filter=lambda rec: rec["extra"].get("name") == "dnsmanager",
     retention="10 days",
     rotation="1d",
     colorize=False)
@@ -59,7 +57,7 @@ def logger_wraps(is_stub: bool = False) -> Callable:
             try:
                 result = await func(*args, **kwargs)
             except DNSConnectionError as err:
-                logger.error(f'{name} call raised: {err}')
+                logger.error(f"{name} call raised: {err}")
                 raise
 
             else:
@@ -131,9 +129,9 @@ class DNSRecords:
 class DNSManagerState(StrEnum):
     """DNSManager state enum."""
 
-    NOT_CONFIGURED = '0'
-    SELFHOSTED = '1'
-    HOSTED = '2'
+    NOT_CONFIGURED = "0"
+    SELFHOSTED = "1"
+    HOSTED = "2"
 
 
 class AbstractDNSManager(ABC):
@@ -163,7 +161,7 @@ class AbstractDNSManager(ABC):
                 f.write(named_conf_local_part)
 
             with open(settings.DNS_SERVER_NAMED_CONF, "a") as f:
-                f.write("\ninclude \"/opt/zone.key\";")
+                f.write('\ninclude "/opt/zone.key";')
 
             with open(settings.DNS_TSIG_KEY, "r") as f:
                 key_file_content = f.read()
@@ -188,25 +186,25 @@ class AbstractDNSManager(ABC):
                 for name, value in new_settings.items()])
 
     @abstractmethod
-    async def create_record( # noqa
+    async def create_record(
         self, hostname: str, ip: str,
         record_type: str, ttl: int | None,
     ) -> None: ...
 
     @abstractmethod
-    async def update_record( # noqa
+    async def update_record(
         self, hostname: str, ip: str | None,
         record_type: str, ttl: int | None,
     ) -> None: ...
 
     @abstractmethod
-    async def delete_record( # noqa
+    async def delete_record(
         self, hostname: str, ip: str,
         record_type: str,
     ) -> None: ...
 
     @abstractmethod
-    async def get_all_records(self) -> list[DNSRecords]: ... # noqa
+    async def get_all_records(self) -> list[DNSRecords]: ...
 
 
 class DNSManager(AbstractDNSManager):
@@ -306,19 +304,19 @@ class StubDNSManager(AbstractDNSManager):
     """Stub client."""
 
     @logger_wraps(is_stub=True)
-    async def create_record( # noqa
+    async def create_record(
         self, hostname: str, ip: str,
         record_type: str, ttl: int | None,
     ) -> None: ...
 
     @logger_wraps(is_stub=True)
-    async def update_record( # noqa
+    async def update_record(
         self, hostname: str, ip: str,
         record_type: str, ttl: int,
     ) -> None: ...
 
     @logger_wraps(is_stub=True)
-    async def delete_record( # noqa
+    async def delete_record(
         self, hostname: str, ip: str,
         record_type: str,
     ) -> None: ...
@@ -331,7 +329,7 @@ class StubDNSManager(AbstractDNSManager):
 
 async def get_dns_state(
     session: AsyncSession,
-) -> 'DNSManagerState':
+) -> "DNSManagerState":
     """Get or create DNS manager state."""
     state = await session.scalar(
         select(CatalogueSetting)
@@ -376,7 +374,7 @@ async def resolve_dns_server_ip(host: str) -> str:
 async def get_dns_manager_settings(
     session: AsyncSession,
     resolve_coro: Awaitable[str],
-) -> 'DNSManagerSettings':
+) -> "DNSManagerSettings":
     """Get DNS manager's settings."""
     settings_dict = {}
     for setting in await session.scalars(
@@ -388,15 +386,15 @@ async def get_dns_manager_settings(
     ):
         settings_dict[setting.name] = setting.value
 
-    dns_server_ip = settings_dict.get(DNS_MANAGER_IP_ADDRESS_NAME, None)
+    dns_server_ip = settings_dict.get(DNS_MANAGER_IP_ADDRESS_NAME)
 
     if await get_dns_state(session) == DNSManagerState.SELFHOSTED:
         dns_server_ip = await resolve_coro
 
     return DNSManagerSettings(
-        zone_name=settings_dict.get(DNS_MANAGER_ZONE_NAME, None),
+        zone_name=settings_dict.get(DNS_MANAGER_ZONE_NAME),
         dns_server_ip=dns_server_ip,
-        tsig_key=settings_dict.get(DNS_MANAGER_TSIG_KEY_NAME, None),
+        tsig_key=settings_dict.get(DNS_MANAGER_TSIG_KEY_NAME),
     )
 
 

--- a/app/ldap_protocol/kerberos.py
+++ b/app/ldap_protocol/kerberos.py
@@ -3,6 +3,7 @@
 Copyright (c) 2024 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
+
 from abc import ABC, abstractmethod
 from enum import StrEnum
 from functools import wraps
@@ -112,7 +113,8 @@ class AbstractKadmin(ABC):
             raise KRBAPIError(response.text)
 
     async def setup_stash(
-        self, domain: str,
+        self,
+        domain: str,
         admin_dn: str,
         services_dn: str,
         krbadmin_dn: str,
@@ -139,7 +141,8 @@ class AbstractKadmin(ABC):
             raise KRBAPIError(response.text)
 
     async def setup_subtree(
-        self, domain: str,
+        self,
+        domain: str,
         admin_dn: str,
         services_dn: str,
         krbadmin_dn: str,
@@ -213,7 +216,10 @@ class AbstractKadmin(ABC):
 
     @abstractmethod
     async def add_principal(
-        self, name: str, password: str | None, timeout: int | float = 1,
+        self,
+        name: str,
+        password: str | None,
+        timeout: int | float = 1,
     ) -> None: ...
 
     @abstractmethod
@@ -224,12 +230,16 @@ class AbstractKadmin(ABC):
 
     @abstractmethod
     async def change_principal_password(
-        self, name: str, password: str,
+        self,
+        name: str,
+        password: str,
     ) -> None: ...
 
     @abstractmethod
     async def create_or_update_principal_pw(
-        self, name: str, password: str,
+        self,
+        name: str,
+        password: str,
     ) -> None: ...
 
     @abstractmethod
@@ -346,18 +356,23 @@ class KerberosMDAPIClient(AbstractKadmin):
 
     @logger_wraps()
     async def change_principal_password(
-        self, name: str, password: str,
+        self,
+        name: str,
+        password: str,
     ) -> None:
         """Change password request."""
         response = await self.client.patch(
-            "principal", json={"name": name, "password": password},
+            "principal",
+            json={"name": name, "password": password},
         )
         if response.status_code != 201:
             raise KRBAPIError(response.text)
 
     @logger_wraps()
     async def create_or_update_principal_pw(
-        self, name: str, password: str,
+        self,
+        name: str,
+        password: str,
     ) -> None:
         """Change password request."""
         response = await self.client.post(
@@ -371,7 +386,8 @@ class KerberosMDAPIClient(AbstractKadmin):
     async def rename_princ(self, name: str, new_name: str) -> None:
         """Rename request."""
         response = await self.client.put(
-            "principal", json={"name": name, "new_name": new_name},
+            "principal",
+            json={"name": name, "new_name": new_name},
         )
         if response.status_code != 202:
             raise KRBAPIError(response.text)
@@ -383,7 +399,9 @@ class KerberosMDAPIClient(AbstractKadmin):
         :return httpx.Response: stream
         """
         request = self.client.build_request(
-            "POST", "/principal/ktadd", json=names,
+            "POST",
+            "/principal/ktadd",
+            json=names,
         )
 
         response = await self.client.send(request, stream=True)
@@ -428,7 +446,8 @@ class KerberosMDAPIClient(AbstractKadmin):
         :raises KRBAPIError: on error
         """
         response = await self.client.post(
-            "principal/lock", json={"name": name},
+            "principal/lock",
+            json={"name": name},
         )
 
         if response.status_code != 200:
@@ -441,7 +460,8 @@ class KerberosMDAPIClient(AbstractKadmin):
         :raises KRBAPIError: err
         """
         response = await self.client.post(
-            "principal/force_reset", json={"name": name},
+            "principal/force_reset",
+            json={"name": name},
         )
 
         if response.status_code != 200:
@@ -465,30 +485,27 @@ class StubKadminMDADPIClient(AbstractKadmin):
     ) -> None: ...
 
     @logger_wraps(is_stub=True)
-    async def get_principal(self, name: str) -> None:
-        ...
+    async def get_principal(self, name: str) -> None: ...
 
     @logger_wraps(is_stub=True)
-    async def del_principal(self, name: str) -> None:
-        ...
+    async def del_principal(self, name: str) -> None: ...
 
     @logger_wraps(is_stub=True)
     async def change_principal_password(
         self,
         name: str,
         password: str,
-    ) -> None:
-        ...
+    ) -> None: ...
 
     @logger_wraps(is_stub=True)
     async def create_or_update_principal_pw(
-        self, name: str, password: str,
-    ) -> None:
-        ...
+        self,
+        name: str,
+        password: str,
+    ) -> None: ...
 
     @logger_wraps(is_stub=True)
-    async def rename_princ(self, name: str, new_name: str) -> None:
-        ...
+    async def rename_princ(self, name: str, new_name: str) -> None: ...
 
     @logger_wraps(is_stub=True)
     async def ktadd(self, names: list[str]) -> NoReturn:
@@ -504,12 +521,10 @@ class StubKadminMDADPIClient(AbstractKadmin):
     ) -> None: ...
 
     @logger_wraps(is_stub=True)
-    async def lock_principal(self, name: str) -> None:
-        ...
+    async def lock_principal(self, name: str) -> None: ...
 
     @logger_wraps(is_stub=True)
-    async def force_princ_pw_change(self, name: str) -> None:
-        ...
+    async def force_princ_pw_change(self, name: str) -> None: ...
 
 
 async def get_krb_server_state(session: AsyncSession) -> "KerberosState":
@@ -533,8 +548,9 @@ async def set_state(session: AsyncSession, state: "KerberosState") -> None:
     entry if there are multiple entries found.
     """
     results = await session.execute(
-        select(CatalogueSetting)
-        .where(CatalogueSetting.name == KERBEROS_STATE_NAME),
+        select(CatalogueSetting).where(
+            CatalogueSetting.name == KERBEROS_STATE_NAME
+        ),
     )
     kerberos_state = results.scalar_one_or_none()
 

--- a/app/ldap_protocol/kerberos.py
+++ b/app/ldap_protocol/kerberos.py
@@ -526,8 +526,7 @@ async def get_krb_server_state(session: AsyncSession) -> "KerberosState":
 
 
 async def set_state(session: AsyncSession, state: "KerberosState") -> None:
-    """
-    Set the server state in the database.
+    """Set the server state in the database.
 
     This function updates the server state in the database by either adding
     a new entry, updating an existing entry, or deleting and re-adding the

--- a/app/ldap_protocol/kerberos.py
+++ b/app/ldap_protocol/kerberos.py
@@ -212,28 +212,28 @@ class AbstractKadmin(ABC):
             )
 
     @abstractmethod
-    async def add_principal(  # noqa
+    async def add_principal(
         self, name: str, password: str | None, timeout: int | float = 1,
     ) -> None: ...
 
     @abstractmethod
-    async def get_principal(self, name: str) -> dict: ...  # noqa
+    async def get_principal(self, name: str) -> dict: ...
 
     @abstractmethod
-    async def del_principal(self, name: str) -> None: ...  # noqa
+    async def del_principal(self, name: str) -> None: ...
 
     @abstractmethod
-    async def change_principal_password(  # noqa
+    async def change_principal_password(
         self, name: str, password: str,
-    ) -> None: ...  # noqa
+    ) -> None: ...
 
     @abstractmethod
-    async def create_or_update_principal_pw(  # noqa
+    async def create_or_update_principal_pw(
         self, name: str, password: str,
-    ) -> None: ...  # noqa
+    ) -> None: ...
 
     @abstractmethod
-    async def rename_princ(self, name: str, new_name: str) -> None: ...  # noqa
+    async def rename_princ(self, name: str, new_name: str) -> None: ...
 
     @backoff.on_exception(
         backoff.constant,
@@ -260,10 +260,10 @@ class AbstractKadmin(ABC):
         return status
 
     @abstractmethod
-    async def ktadd(self, names: list[str]) -> httpx.Response: ...  # noqa
+    async def ktadd(self, names: list[str]) -> httpx.Response: ...
 
     @abstractmethod
-    async def create_or_update_policy(  # noqa
+    async def create_or_update_policy(
         self,
         minlife: int,
         maxlife: int,
@@ -272,10 +272,10 @@ class AbstractKadmin(ABC):
     ) -> None: ...
 
     @abstractmethod
-    async def lock_principal(self, name: str) -> None: ...  # noqa
+    async def lock_principal(self, name: str) -> None: ...
 
     @abstractmethod
-    async def force_princ_pw_change(self, name: str) -> None: ...  # noqa
+    async def force_princ_pw_change(self, name: str) -> None: ...
 
     async def ldap_principal_setup(self, name: str, path: str) -> None:
         """LDAP principal setup.
@@ -457,7 +457,7 @@ class StubKadminMDADPIClient(AbstractKadmin):
         await super().setup(*args, **kwargs)
 
     @logger_wraps(is_stub=True)
-    async def add_principal(  # noqa D102
+    async def add_principal(
         self,
         name: str,
         password: str | None,
@@ -465,37 +465,37 @@ class StubKadminMDADPIClient(AbstractKadmin):
     ) -> None: ...
 
     @logger_wraps(is_stub=True)
-    async def get_principal(self, name: str) -> None:  # noqa D102
+    async def get_principal(self, name: str) -> None:
         ...
 
     @logger_wraps(is_stub=True)
-    async def del_principal(self, name: str) -> None:  # noqa D102
+    async def del_principal(self, name: str) -> None:
         ...
 
     @logger_wraps(is_stub=True)
-    async def change_principal_password(  # noqa D102
+    async def change_principal_password(
         self,
         name: str,
         password: str,
-    ) -> None:  # noqa
+    ) -> None:
         ...
 
     @logger_wraps(is_stub=True)
-    async def create_or_update_principal_pw(  # noqa D102
+    async def create_or_update_principal_pw(
         self, name: str, password: str,
-    ) -> None:  # noqa
+    ) -> None:
         ...
 
     @logger_wraps(is_stub=True)
-    async def rename_princ(self, name: str, new_name: str) -> None:  # noqa D102
+    async def rename_princ(self, name: str, new_name: str) -> None:
         ...
 
     @logger_wraps(is_stub=True)
-    async def ktadd(self, names: list[str]) -> NoReturn:  # noqa
+    async def ktadd(self, names: list[str]) -> NoReturn:
         raise KRBAPIError
 
     @logger_wraps(is_stub=True)
-    async def create_or_update_policy(  # noqa
+    async def create_or_update_policy(
         self,
         minlife: int,
         maxlife: int,
@@ -504,11 +504,11 @@ class StubKadminMDADPIClient(AbstractKadmin):
     ) -> None: ...
 
     @logger_wraps(is_stub=True)
-    async def lock_principal(self, name: str) -> None:  # noqa
+    async def lock_principal(self, name: str) -> None:
         ...
 
     @logger_wraps(is_stub=True)
-    async def force_princ_pw_change(self, name: str) -> None:  # noqa
+    async def force_princ_pw_change(self, name: str) -> None:
         ...
 
 

--- a/app/ldap_protocol/ldap_requests/__init__.py
+++ b/app/ldap_protocol/ldap_requests/__init__.py
@@ -27,8 +27,9 @@ requests: list[type[BaseRequest]] = [
 ]
 
 protocol_id_map: dict[int, type[BaseRequest]] = {
-    request.PROTOCOL_OP: request for request in requests
-}  # type: ignore
+    request.PROTOCOL_OP: request  # type: ignore
+    for request in requests
+}
 
 
 __all__ = ["protocol_id_map", "BaseRequest"]

--- a/app/ldap_protocol/ldap_requests/__init__.py
+++ b/app/ldap_protocol/ldap_requests/__init__.py
@@ -27,7 +27,8 @@ requests: list[type[BaseRequest]] = [
 ]
 
 protocol_id_map: dict[int, type[BaseRequest]] = {
-    request.PROTOCOL_OP: request for request in requests}  # type: ignore
+    request.PROTOCOL_OP: request for request in requests
+}  # type: ignore
 
 
 __all__ = ["protocol_id_map", "BaseRequest"]

--- a/app/ldap_protocol/ldap_requests/add.py
+++ b/app/ldap_protocol/ldap_requests/add.py
@@ -104,8 +104,7 @@ class AddRequest(BaseRequest):
         root_dn = get_search_path(self.entry)
 
         exists_q = select(
-            select(Directory)
-            .filter(get_path_filter(root_dn)).exists(),
+            select(Directory).filter(get_path_filter(root_dn)).exists(),
         )
 
         if await session.scalar(exists_q) is True:
@@ -187,8 +186,9 @@ class AddRequest(BaseRequest):
         user_attributes: dict[str, str] = {}
         group_attributes: list[str] = []
         user_fields = User.search_fields.keys() | User.fields.keys()
-        attributes.append(Attribute(
-            name=new_dn, value=name, directory=new_dir))
+        attributes.append(
+            Attribute(name=new_dn, value=name, directory=new_dir)
+        )
 
         for attr in self.attributes:
             lname = attr.type.lower()
@@ -239,10 +239,12 @@ class AddRequest(BaseRequest):
             )
 
             sam_accout_name = user_attributes.get(
-                "sAMAccountName", create_user_name(new_dir.id),
+                "sAMAccountName",
+                create_user_name(new_dir.id),
             )
             user_principal_name = user_attributes.get(
-                "userPrincipalName", f"{sam_accout_name!r}@{base_dn.name}",
+                "userPrincipalName",
+                f"{sam_accout_name!r}@{base_dn.name}",
             )
             user = User(
                 sam_accout_name=sam_accout_name,
@@ -316,9 +318,7 @@ class AddRequest(BaseRequest):
         if (is_user or is_group) and "gidnumber" not in self.attr_names:
             reverse_d_name = new_dir.name[::-1]
             value = (
-                "513"
-                if is_user
-                else str(create_integer_hash(reverse_d_name))
+                "513" if is_user else str(create_integer_hash(reverse_d_name))
             )
             attributes.append(
                 Attribute(
@@ -348,7 +348,8 @@ class AddRequest(BaseRequest):
                     await kadmin.add_principal(user.get_upn_prefix(), pw)
                 if is_computer:
                     await kadmin.add_principal(
-                        f"{new_dir.host_principal}.{base_dn.name}", None,
+                        f"{new_dir.host_principal}.{base_dn.name}",
+                        None,
                     )
                     await kadmin.add_principal(new_dir.host_principal, None)
             except KRBAPIError:

--- a/app/ldap_protocol/ldap_requests/add.py
+++ b/app/ldap_protocol/ldap_requests/add.py
@@ -70,7 +70,7 @@ class AddRequest(BaseRequest):
     password: SecretStr | None = Field(None, examples=["password"])
 
     @property
-    def attr_names(self) -> dict[str, list[str | bytes]]:  # noqa: D102
+    def attr_names(self) -> dict[str, list[str | bytes]]:
         return {attr.type.lower(): attr.vals for attr in self.attributes}
 
     @classmethod
@@ -86,7 +86,7 @@ class AddRequest(BaseRequest):
         ]
         return cls(entry=entry.value, attributes=attributes)  # type: ignore
 
-    async def handle(
+    async def handle(  # noqa: C901
         self,
         session: AsyncSession,
         ldap_session: LDAPSession,
@@ -313,7 +313,7 @@ class AddRequest(BaseRequest):
                 ),
             )
 
-        if (is_user or is_group) and 'gidnumber' not in self.attr_names:
+        if (is_user or is_group) and "gidnumber" not in self.attr_names:
             reverse_d_name = new_dir.name[::-1]
             value = (
                 "513"

--- a/app/ldap_protocol/ldap_requests/base.py
+++ b/app/ldap_protocol/ldap_requests/base.py
@@ -64,7 +64,8 @@ class BaseRequest(ABC, _APIProtocol, BaseModel):
         """Protocol OP response code."""
 
     async def _handle_api(
-        self, container: AsyncContainer,
+        self,
+        container: AsyncContainer,
     ) -> list[BaseResponse]:
         """Hanlde response with api user.
 

--- a/app/ldap_protocol/ldap_requests/base.py
+++ b/app/ldap_protocol/ldap_requests/base.py
@@ -35,7 +35,7 @@ log_api.add(
 )
 
 handler: TypeAlias = Callable[..., AsyncGenerator[BaseResponse, None]]
-serializer: TypeAlias = Callable[..., 'BaseRequest']
+serializer: TypeAlias = Callable[..., "BaseRequest"]
 
 
 if TYPE_CHECKING:
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
         ) -> list[BaseResponse] | BaseResponse: ...
 else:
 
-    class _APIProtocol: ...  # noqa
+    class _APIProtocol: ...
 
 
 class BaseRequest(ABC, _APIProtocol, BaseModel):

--- a/app/ldap_protocol/ldap_requests/bind.py
+++ b/app/ldap_protocol/ldap_requests/bind.py
@@ -53,7 +53,8 @@ class BindRequest(BaseRequest):
     version: int
     name: str
     authentication_choice: AbstractLDAPAuth = Field(
-        ..., alias="AuthenticationChoice",
+        ...,
+        alias="AuthenticationChoice",
     )
 
     @classmethod
@@ -94,7 +95,9 @@ class BindRequest(BaseRequest):
 
     @staticmethod
     async def is_user_group_valid(
-        user: User, ldap_session: LDAPSession, session: AsyncSession,
+        user: User,
+        ldap_session: LDAPSession,
+        session: AsyncSession,
     ) -> bool:
         """Test compability."""
         return await is_user_group_valid(user, ldap_session.policy, session)
@@ -165,7 +168,8 @@ class BindRequest(BaseRequest):
             return
 
         pwd_policy = await PasswordPolicySchema.get_policy_settings(
-            session, kadmin,
+            session,
+            kadmin,
         )
         p_last_set = await pwd_policy.get_pwd_last_set(
             session, user.directory_id
@@ -231,7 +235,8 @@ class UnbindRequest(BaseRequest):
         return cls()
 
     async def handle(
-        self, ldap_session: LDAPSession,
+        self,
+        ldap_session: LDAPSession,
     ) -> AsyncGenerator[BaseResponse, None]:
         """Handle unbind request, no need to send response."""
         await ldap_session.delete_user()

--- a/app/ldap_protocol/ldap_requests/bind.py
+++ b/app/ldap_protocol/ldap_requests/bind.py
@@ -4,6 +4,7 @@ Copyright (c) 2024 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
 
+import contextlib
 from typing import AsyncGenerator, ClassVar
 
 import httpx
@@ -77,7 +78,7 @@ class BindRequest(BaseRequest):
                 password=password,
                 otpassword=otpassword,
             )
-        elif auth == SaslAuthentication.METHOD_ID:  # noqa: R506
+        elif auth == SaslAuthentication.METHOD_ID:
             sasl_method = data[2].value[0].value
             auth_choice = sasl_mechanism_map[sasl_method].from_data(
                 data[2].value,
@@ -118,15 +119,11 @@ class BindRequest(BaseRequest):
         try:
             return await api.ldap_validate_mfa(identity, otp)
         except MultifactorAPI.MFAConnectError:
-            if policy.bypass_no_connection:
-                return True
-            return False
+            return bool(policy.bypass_no_connection)
         except MultifactorAPI.MFAMissconfiguredError:
             return True
         except MultifactorAPI.MultifactorError:
-            if policy.bypass_service_failure:
-                return True
-            return False
+            return bool(policy.bypass_service_failure)
 
     async def handle(
         self,
@@ -141,14 +138,15 @@ class BindRequest(BaseRequest):
             yield BindResponse(result_code=LDAPCodes.SUCCESS)
             return
 
-        if isinstance(self.authentication_choice, SaslGSSAPIAuthentication):
-            if response := await self.authentication_choice.step(
-                session,
-                ldap_session,
-                settings,
-            ):
-                yield response
-                return
+        if isinstance(
+            self.authentication_choice, SaslGSSAPIAuthentication
+        ) and (
+            response := await self.authentication_choice.step(
+                session, ldap_session, settings
+            )
+        ):
+            yield response
+            return
 
         user = await self.authentication_choice.get_user(session, self.name)
 
@@ -166,11 +164,13 @@ class BindRequest(BaseRequest):
             yield get_bad_response(LDAPBindErrors.LOGON_FAILURE)
             return
 
-        policy = await PasswordPolicySchema.get_policy_settings(
+        pwd_policy = await PasswordPolicySchema.get_policy_settings(
             session, kadmin,
         )
-        p_last_set = await policy.get_pwd_last_set(session, user.directory_id)
-        pwd_expired = policy.validate_max_age(p_last_set)
+        p_last_set = await pwd_policy.get_pwd_last_set(
+            session, user.directory_id
+        )
+        pwd_expired = pwd_policy.validate_max_age(p_last_set)
 
         is_krb_user = await check_kerberos_group(user, session)
 
@@ -186,33 +186,33 @@ class BindRequest(BaseRequest):
             yield get_bad_response(LDAPBindErrors.PASSWORD_MUST_CHANGE)
             return
 
-        if policy := getattr(ldap_session, "policy", None):  # type: ignore
-            if policy.mfa_status in (MFAFlags.ENABLED, MFAFlags.WHITELIST):
+        policy = getattr(ldap_session, "policy", None)
+        if policy and policy.mfa_status in (
+            MFAFlags.ENABLED,
+            MFAFlags.WHITELIST,
+        ):
+            request_2fa = True
+            if policy.mfa_status == MFAFlags.WHITELIST:
+                request_2fa = await check_mfa_group(policy, user, session)
 
-                request_2fa = True
-                if policy.mfa_status == MFAFlags.WHITELIST:
-                    request_2fa = await check_mfa_group(policy, user, session)
+            if request_2fa:
+                mfa_status = await self.check_mfa(
+                    mfa,
+                    user.user_principal_name,
+                    self.authentication_choice.otpassword,
+                    policy,
+                )
 
-                if request_2fa:
-                    mfa_status = await self.check_mfa(
-                        mfa,
-                        user.user_principal_name,
-                        self.authentication_choice.otpassword,
-                        policy,
-                    )
+                if mfa_status is False:
+                    yield get_bad_response(LDAPBindErrors.LOGON_FAILURE)
+                    return
 
-                    if mfa_status is False:
-                        yield get_bad_response(LDAPBindErrors.LOGON_FAILURE)
-                        return
-
-        try:
+        with contextlib.suppress(KRBAPIError, httpx.TimeoutException):
             await kadmin.add_principal(
                 user.get_upn_prefix(),
                 self.authentication_choice.password.get_secret_value(),
                 0.1,
             )
-        except (KRBAPIError, httpx.TimeoutException):
-            pass
 
         await ldap_session.set_user(user)
         await set_last_logon_user(user, session, settings.TIMEZONE)

--- a/app/ldap_protocol/ldap_requests/bind_methods/base.py
+++ b/app/ldap_protocol/ldap_requests/bind_methods/base.py
@@ -47,7 +47,7 @@ class LDAPBindErrors(StrEnum):
     PASSWORD_MUST_CHANGE = "773"  # noqa
     ACCOUNT_LOCKED_OUT = "775"
 
-    def __str__(self) -> str:  # noqa
+    def __str__(self) -> str:
         return (
             "80090308: LdapErr: DSID-0C09030B, "
             "comment: AcceptSecurityContext error, "
@@ -79,7 +79,7 @@ class AbstractLDAPAuth(ABC, BaseModel):
 
     @property
     @abstractmethod
-    def METHOD_ID(self) -> int:  # noqa: N802, D102
+    def METHOD_ID(self) -> int:  # noqa: N802
         """Abstract method id."""
 
     @abstractmethod

--- a/app/ldap_protocol/ldap_requests/bind_methods/sasl_gssapi.py
+++ b/app/ldap_protocol/ldap_requests/bind_methods/sasl_gssapi.py
@@ -35,9 +35,7 @@ class GSSAPISL(IntEnum):
     CONFIDENTIALITY = 4
 
     SUPPORTED_SECURITY_LAYERS = (
-        NO_SECURITY
-        | INTEGRITY_PROTECTION
-        | CONFIDENTIALITY
+        NO_SECURITY | INTEGRITY_PROTECTION | CONFIDENTIALITY
     )
 
 
@@ -137,7 +135,8 @@ class SaslGSSAPIAuthentication(SaslAuthentication):
         )
 
     def _handle_ticket(
-        self, server_ctx: gssapi.SecurityContext,
+        self,
+        server_ctx: gssapi.SecurityContext,
     ) -> GSSAPIAuthStatus:
         """Handle the ticket and make gssapi step.
 
@@ -152,7 +151,9 @@ class SaslGSSAPIAuthentication(SaslAuthentication):
             return GSSAPIAuthStatus.ERROR
 
     def _validate_security_layer(
-        self, client_layer: GSSAPISL, settings: Settings,
+        self,
+        client_layer: GSSAPISL,
+        settings: Settings,
     ) -> bool:
         """Validate security layer.
 
@@ -183,18 +184,22 @@ class SaslGSSAPIAuthentication(SaslAuthentication):
                     ),
                 )
                 if self._validate_security_layer(
-                    client_security_layer, settings,
+                    client_security_layer,
+                    settings,
                 ):
                     self._ldap_session.gssapi_authenticated = True
-                    self._ldap_session.gssapi_security_layer = \
+                    self._ldap_session.gssapi_security_layer = (
                         client_security_layer
+                    )
                     return GSSAPIAuthStatus.COMPLETE
             return GSSAPIAuthStatus.ERROR
         except gssapi.exceptions.GSSError:
             return GSSAPIAuthStatus.ERROR
 
     def _generate_final_message(
-        self, server_ctx: gssapi.SecurityContext, settings: Settings,
+        self,
+        server_ctx: gssapi.SecurityContext,
+        settings: Settings,
     ) -> bytes:
         """Generate final wrap message.
 
@@ -207,8 +212,8 @@ class SaslGSSAPIAuthentication(SaslAuthentication):
             max_size = 0  # type: ignore
 
         message = (
-            GSSAPISL.SUPPORTED_SECURITY_LAYERS.to_bytes() +
-            max_size.to_bytes(length=3)
+            GSSAPISL.SUPPORTED_SECURITY_LAYERS.to_bytes()
+            + max_size.to_bytes(length=3)
         )
 
         wrap_message = server_ctx.wrap(message, encrypt=False)
@@ -237,7 +242,8 @@ class SaslGSSAPIAuthentication(SaslAuthentication):
 
         if self.ticket == b"":
             self.server_sasl_creds = self._generate_final_message(
-                server_ctx, settings,
+                server_ctx,
+                settings,
             )
             return BindResponse(
                 result_code=LDAPCodes.SASL_BIND_IN_PROGRESS,
@@ -246,7 +252,8 @@ class SaslGSSAPIAuthentication(SaslAuthentication):
 
         if server_ctx.complete:
             status = self._handle_final_client_message(
-                server_ctx, settings,
+                server_ctx,
+                settings,
             )
             if status == GSSAPIAuthStatus.COMPLETE:
                 return None

--- a/app/ldap_protocol/ldap_requests/bind_methods/sasl_gssapi.py
+++ b/app/ldap_protocol/ldap_requests/bind_methods/sasl_gssapi.py
@@ -276,5 +276,5 @@ class SaslGSSAPIAuthentication(SaslAuthentication):
         if not ctx:
             return None
 
-        username = str(ctx.initiator_name).split('@')[0]
+        username = str(ctx.initiator_name).split("@")[0]
         return await get_user(session, username)

--- a/app/ldap_protocol/ldap_requests/bind_methods/sasl_plain.py
+++ b/app/ldap_protocol/ldap_requests/bind_methods/sasl_plain.py
@@ -32,7 +32,8 @@ class SaslPLAINAuthentication(SaslAuthentication):
         password = getattr(user, "password", None)
         if password is not None:
             return verify_password(
-                self.password.get_secret_value(), password,
+                self.password.get_secret_value(),
+                password,
             )
         return False
 

--- a/app/ldap_protocol/ldap_requests/delete.py
+++ b/app/ldap_protocol/ldap_requests/delete.py
@@ -42,7 +42,7 @@ class DeleteRequest(BaseRequest):
     entry: str
 
     @classmethod
-    def from_data(cls, data: ASN1Row) -> "DeleteRequest":  # noqa: D102
+    def from_data(cls, data: ASN1Row) -> "DeleteRequest":
         return cls(entry=data)
 
     async def handle(

--- a/app/ldap_protocol/ldap_requests/extended.py
+++ b/app/ldap_protocol/ldap_requests/extended.py
@@ -201,19 +201,21 @@ class PasswdModifyRequestValue(BaseExtendedValue):
             if not ldap_session.user:
                 raise PermissionError("Anonymous user")
 
-            user = await session.get(
-                User, ldap_session.user.id)  # type: ignore
+            user = await session.get(User, ldap_session.user.id)  # type: ignore
 
         validator = await PasswordPolicySchema.get_policy_settings(
-            session, kadmin,
+            session,
+            kadmin,
         )
 
         errors = await validator.validate_password_with_policy(
-            self.new_password, user,
+            self.new_password,
+            user,
         )
 
         p_last_set = await validator.get_pwd_last_set(
-            session, user.directory_id,
+            session,
+            user.directory_id,
         )
 
         if validator.validate_min_age(p_last_set):
@@ -232,7 +234,8 @@ class PasswdModifyRequestValue(BaseExtendedValue):
 
             try:
                 await kadmin.create_or_update_principal_pw(
-                    user.get_upn_prefix(), self.new_password,
+                    user.get_upn_prefix(),
+                    self.new_password,
                 )
             except KRBAPIError:
                 await session.rollback()
@@ -289,7 +292,10 @@ class ExtendedRequest(BaseRequest):
         """Call proxy handler."""
         try:
             response = await self.request_value.handle(
-                ldap_session, session, kadmin, settings,
+                ldap_session,
+                session,
+                kadmin,
+                settings,
             )
         except PermissionError as err:
             logger.critical(err)

--- a/app/ldap_protocol/ldap_requests/extended.py
+++ b/app/ldap_protocol/ldap_requests/extended.py
@@ -292,7 +292,7 @@ class ExtendedRequest(BaseRequest):
                 ldap_session, session, kadmin, settings,
             )
         except PermissionError as err:
-            logger.critical(err)  # noqa
+            logger.critical(err)
             yield ExtendedResponse(
                 result_code=LDAPCodes.OPERATIONS_ERROR,
                 response_name=self.request_name,

--- a/app/ldap_protocol/ldap_requests/modify.py
+++ b/app/ldap_protocol/ldap_requests/modify.py
@@ -234,8 +234,7 @@ class ModifyRequest(BaseRequest):
         name = change.modification.type.lower()
 
         if name == "memberof":
-            groups = await get_groups(
-                change.modification.vals, session)  # type: ignore
+            groups = await get_groups(change.modification.vals, session)  # type: ignore
 
             if not change.modification.vals:
                 directory.groups.clear()
@@ -250,8 +249,7 @@ class ModifyRequest(BaseRequest):
             return
 
         if name == "member":
-            members = await get_directories(
-                change.modification.vals, session)  # type: ignore
+            members = await get_directories(change.modification.vals, session)  # type: ignore
 
             if not change.modification.vals:
                 directory.group.members.clear()
@@ -285,7 +283,8 @@ class ModifyRequest(BaseRequest):
 
         if attrs:
             del_query = delete(Attribute).filter(
-                Attribute.directory == directory, or_(*attrs),
+                Attribute.directory == directory,
+                or_(*attrs),
             )
 
             await session.execute(del_query)
@@ -297,8 +296,7 @@ class ModifyRequest(BaseRequest):
         session: AsyncSession,
     ) -> None:
         name = change.get_name()
-        directories = await get_directories(
-            change.modification.vals, session)  # type: ignore
+        directories = await get_directories(change.modification.vals, session)  # type: ignore
 
         if name == "memberof":
             groups = [
@@ -382,20 +380,19 @@ class ModifyRequest(BaseRequest):
                     and directory.user
                 ):
                     await unlock_principal(
-                        directory.user.user_principal_name, session,
+                        directory.user.user_principal_name,
+                        session,
                     )
 
                     await session.execute(
-                        delete(Attribute)
-                        .filter(
+                        delete(Attribute).filter(
                             Attribute.name == "nsAccountLock",
                             Attribute.directory == directory,
                         ),
                     )
 
                     await session.execute(
-                        delete(Attribute)
-                        .filter(
+                        delete(Attribute).filter(
                             Attribute.name == "shadowExpire",
                             Attribute.directory == directory,
                         ),
@@ -477,15 +474,18 @@ class ModifyRequest(BaseRequest):
                     pass
 
                 validator = await PasswordPolicySchema.get_policy_settings(
-                    session, kadmin,
+                    session,
+                    kadmin,
                 )
 
                 p_last_set = await validator.get_pwd_last_set(
-                    session, directory.id,
+                    session,
+                    directory.id,
                 )
 
                 errors = await validator.validate_password_with_policy(
-                    value, directory.user,
+                    value,
+                    directory.user,
                 )
 
                 if validator.validate_min_age(p_last_set):
@@ -499,7 +499,8 @@ class ModifyRequest(BaseRequest):
                 directory.user.password = get_password_hash(value)
                 await post_save_password_actions(directory.user, session)
                 await kadmin.create_or_update_principal_pw(
-                    directory.user.get_upn_prefix(), value,
+                    directory.user.get_upn_prefix(),
+                    value,
                 )
 
             else:
@@ -509,6 +510,7 @@ class ModifyRequest(BaseRequest):
                         value=value if isinstance(value, str) else None,
                         bvalue=value if isinstance(value, bytes) else None,
                         directory=directory,
-                    ))
+                    )
+                )
 
         session.add_all(attrs)

--- a/app/ldap_protocol/ldap_requests/modify.py
+++ b/app/ldap_protocol/ldap_requests/modify.py
@@ -90,11 +90,11 @@ class ModifyRequest(BaseRequest):
 
     PROTOCOL_OP: ClassVar[int] = 6
 
-    object: str  # noqa: A003
+    object: str
     changes: list[Changes]
 
     @classmethod
-    def from_data(cls, data: list[ASN1Row]) -> "ModifyRequest":  # noqa: D102
+    def from_data(cls, data: list[ASN1Row]) -> "ModifyRequest":
         entry, proto_changes = data
 
         changes = []
@@ -131,7 +131,7 @@ class ModifyRequest(BaseRequest):
             yield ModifyResponse(result_code=LDAPCodes.INVALID_DN_SYNTAX)
             return
 
-        query = (  # noqa: ECE001
+        query = (
             select(Directory)
             .join(Directory.attributes)
             .options(
@@ -356,7 +356,7 @@ class ModifyRequest(BaseRequest):
             if name == "useraccountcontrol":
                 uac_val = int(value)
 
-                if not UserAccountControlFlag.is_value_valid(uac_val):  # noqa
+                if not UserAccountControlFlag.is_value_valid(uac_val):
                     continue
 
                 elif (
@@ -468,7 +468,7 @@ class ModifyRequest(BaseRequest):
                     raise PermissionError("TLS required")
 
                 if isinstance(value, bytes):
-                    raise ValueError('password is bytes')
+                    raise ValueError("password is bytes")
 
                 try:
                     value = value.replace("\\x00", "\x00")

--- a/app/ldap_protocol/ldap_requests/modify_dn.py
+++ b/app/ldap_protocol/ldap_requests/modify_dn.py
@@ -200,7 +200,7 @@ class ModifyDNRequest(BaseRequest):
             await session.flush()
 
             if self.deleteoldrdn:
-                old_attr_name = directory.path[-1].split('=')[0]
+                old_attr_name = directory.path[-1].split("=")[0]
                 await session.execute(
                     update(Attribute)
                     .where(

--- a/app/ldap_protocol/ldap_requests/modify_dn.py
+++ b/app/ldap_protocol/ldap_requests/modify_dn.py
@@ -65,7 +65,7 @@ class ModifyDNRequest(BaseRequest):
         deleteoldrdn=true
         new_superior='ou=users,dc=multifactor,dc=dev'
 
-        >>> cn=main2,ou=users,dc=multifactor,dc=dev
+        >>> cn = main2, ou = users, dc = multifactor, dc = dev
     """
 
     PROTOCOL_OP: ClassVar[int] = 12
@@ -190,7 +190,6 @@ class ModifyDNRequest(BaseRequest):
             return
 
         async with session.begin_nested():
-
             await session.execute(
                 update(Directory)
                 .where(Directory.parent == directory)
@@ -234,7 +233,7 @@ class ModifyDNRequest(BaseRequest):
                 .where(
                     get_path_filter(
                         directory.path,
-                        column=Directory.path[1:directory.depth],
+                        column=Directory.path[1 : directory.depth],
                     ),
                 )
                 .values(

--- a/app/ldap_protocol/ldap_responses.py
+++ b/app/ldap_protocol/ldap_responses.py
@@ -33,7 +33,7 @@ class LDAPResult(BaseModel):
     matched_dn: str = Field("", alias="matchedDN")
     error_message: str = Field("", alias="errorMessage")
 
-    class Config:  # noqa
+    class Config:
         populate_by_name = True
         arbitrary_types_allowed = True
         json_encoders = {
@@ -44,7 +44,7 @@ class LDAPResult(BaseModel):
 class BaseEncoder(BaseModel):
     """Class with encoder methods."""
 
-    def _get_asn1_fields(self) -> dict:  # noqa
+    def _get_asn1_fields(self) -> dict:
         fields = self.model_dump()
         fields.pop("PROTOCOL_OP", None)
         return fields
@@ -60,7 +60,7 @@ class BaseResponse(ABC, BaseEncoder):
 
     @property
     @abstractmethod
-    def PROTOCOL_OP(self) -> int:  # noqa: N802, D102
+    def PROTOCOL_OP(self) -> int:  # noqa: N802
         """Protocol OP response code."""
 
 
@@ -92,17 +92,17 @@ class BindResponse(LDAPResult, BaseResponse):
 class PartialAttribute(BaseModel):
     """Partial attribite structure. Description in rfc2251 4.1.6."""
 
-    type: Annotated[str, annotated_types.Len(max_length=8100)]  # noqa: A003
+    type: Annotated[str, annotated_types.Len(max_length=8100)]
     vals: list[Annotated[str | bytes, annotated_types.Len(max_length=100000)]]
 
     @field_validator("type", mode="before")
     @classmethod
-    def validate_type(cls, v: str | bytes | int) -> str:  # noqa
+    def validate_type(cls, v: str | bytes | int) -> str:
         return str(v)
 
     @field_validator("vals", mode="before")
     @classmethod
-    def validate_vals(cls, vals: list[str | int | bytes]) -> list[str | bytes]:  # noqa
+    def validate_vals(cls, vals: list[str | int | bytes]) -> list[str | bytes]:
         return [v if isinstance(v, bytes) else str(v) for v in vals]
 
     class Config:
@@ -161,7 +161,7 @@ class SearchResultDone(LDAPResult, BaseResponse):
     total_pages: int = 0
     total_objects: int = 0
 
-    def _get_asn1_fields(self) -> dict:  # noqa
+    def _get_asn1_fields(self) -> dict:
         fields = super()._get_asn1_fields()
         fields.pop("total_pages")
         fields.pop("total_objects")

--- a/app/ldap_protocol/multifactor.py
+++ b/app/ldap_protocol/multifactor.py
@@ -197,9 +197,7 @@ class MultifactorAPI:
             },
         )
 
-        if data.get("model", {}).get("status") != "Granted":
-            return False
-        return True
+        return data.get("model", {}).get("status") == "Granted"
 
     @log_mfa.catch(reraise=True)
     async def get_create_mfa(

--- a/app/ldap_protocol/multifactor.py
+++ b/app/ldap_protocol/multifactor.py
@@ -98,6 +98,7 @@ class MultifactorAPI:
     - `REFRESH_URL`: Endpoint URL for token refresh.
     - `client`: Asynchronous HTTP client for making requests.
     - `settings`: Configuration settings for the MFA service.
+
     """
 
     MultifactorError = _MultifactorError

--- a/app/ldap_protocol/multifactor.py
+++ b/app/ldap_protocol/multifactor.py
@@ -61,7 +61,8 @@ async def get_creds(
     :return tuple[str, str]: api key and secret
     """
     query = select(CatalogueSetting).where(
-        CatalogueSetting.name.in_([key_name, secret_name]))
+        CatalogueSetting.name.in_([key_name, secret_name])
+    )
 
     vals = await session.scalars(query)
     secrets = {s.name: s.value for s in vals.all()}
@@ -202,7 +203,10 @@ class MultifactorAPI:
 
     @log_mfa.catch(reraise=True)
     async def get_create_mfa(
-        self, username: str, callback_url: str, uid: int,
+        self,
+        username: str,
+        callback_url: str,
+        uid: int,
     ) -> str:
         """Create mfa link.
 

--- a/app/ldap_protocol/policies/access_policy.py
+++ b/app/ldap_protocol/policies/access_policy.py
@@ -90,8 +90,8 @@ def mutate_ap(
 
     if action == "read":
         user_path = get_search_path(user.dn)
-        get_upper_tree_elem = text(  # noqa: F811
-            "(:path)[1:\"Directory\".\"depth\"]",
+        get_upper_tree_elem = text(
+            '(:path)[1:"Directory"."depth"]',
         ).bindparams(bindparam("path", value=user_path, type_=ARRAY(String)))
 
         ap_filter = or_(

--- a/app/ldap_protocol/policies/access_policy.py
+++ b/app/ldap_protocol/policies/access_policy.py
@@ -55,7 +55,7 @@ async def create_access_policy(
     """
     path = get_search_path(grant_dn)
     dir_filter = get_path_filter(
-        column=Directory.path[1:len(path)],
+        column=Directory.path[1 : len(path)],
         path=path,
     )
 

--- a/app/ldap_protocol/policies/network_policy.py
+++ b/app/ldap_protocol/policies/network_policy.py
@@ -29,7 +29,7 @@ def build_policy_query(
     :return: Select query
     """
     protocol_field = getattr(NetworkPolicy, protocol_field_name)
-    query = ( # noqa
+    query = (
         select(NetworkPolicy)
         .filter_by(enabled=True)
         .options(
@@ -114,7 +114,7 @@ async def is_user_group_valid(
     if not policy.groups:
         return True
 
-    query = (  # noqa: ECE001
+    query = (
         select(Group)
         .join(Group.users)
         .join(Group.policies, isouter=True)

--- a/app/ldap_protocol/policies/network_policy.py
+++ b/app/ldap_protocol/policies/network_policy.py
@@ -19,8 +19,7 @@ def build_policy_query(
     protocol_field_name: Literal["is_http", "is_ldap", "is_kerberos"],
     user_group_ids: list[int] | None = None,
 ) -> Select:
-    """
-    Build a base query for network policies with optional group filtering.
+    """Build a base query for network policies with optional group filtering.
 
     :param IPv4Address ip: IP address to filter
     :param Literal["is_http", "is_ldap", "is_kerberos"] protocol_field_name
@@ -82,8 +81,7 @@ async def get_user_network_policy(
     user: User,
     session: AsyncSession,
 ) -> NetworkPolicy | None:
-    """
-    Get the highest priority network policy for user, ip and protocol.
+    """Get the highest priority network policy for user, ip and protocol.
 
     :param User user: user object
     :param AsyncSession session: db session

--- a/app/ldap_protocol/policies/network_policy.py
+++ b/app/ldap_protocol/policies/network_policy.py
@@ -3,6 +3,7 @@
 Copyright (c) 2024 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
+
 from ipaddress import IPv4Address, IPv6Address
 from typing import Literal
 

--- a/app/ldap_protocol/policies/password_policy.py
+++ b/app/ldap_protocol/policies/password_policy.py
@@ -201,9 +201,7 @@ class PasswordPolicySchema(BaseModel):
 
         password_exists = self._count_password_exists_days(last_pwd_set)
 
-        if password_exists < self.minimum_password_age_days:
-            return True
-        return False
+        return password_exists < self.minimum_password_age_days
 
     def validate_max_age(self, last_pwd_set: Attribute) -> bool:
         """Validate max password change age.
@@ -220,9 +218,7 @@ class PasswordPolicySchema(BaseModel):
 
         password_exists = self._count_password_exists_days(last_pwd_set)
 
-        if password_exists > self.maximum_password_age_days:
-            return True
-        return False
+        return password_exists > self.maximum_password_age_days
 
     async def validate_password_with_policy(
         self,

--- a/app/ldap_protocol/policies/password_policy.py
+++ b/app/ldap_protocol/policies/password_policy.py
@@ -25,7 +25,8 @@ with open("extra/common_pwds.txt") as f:
 
 
 async def post_save_password_actions(
-    user: User, session: AsyncSession,
+    user: User,
+    session: AsyncSession,
 ) -> None:
     """Post save actions for password update.
 
@@ -59,7 +60,9 @@ class PasswordPolicySchema(BaseModel):
     """PasswordPolicy schema."""
 
     name: str = Field(
-        "Default domain password policy", min_length=3, max_length=255,
+        "Default domain password policy",
+        min_length=3,
+        max_length=255,
     )
     password_history_length: int = Field(4, ge=0, le=24)
     maximum_password_age_days: int = Field(0, ge=0, le=999)
@@ -77,7 +80,9 @@ class PasswordPolicySchema(BaseModel):
         return self
 
     async def create_policy_settings(
-        self, session: AsyncSession, kadmin: AbstractKadmin,
+        self,
+        session: AsyncSession,
+        kadmin: AbstractKadmin,
     ) -> Self:
         """Create policies settings.
 
@@ -99,7 +104,9 @@ class PasswordPolicySchema(BaseModel):
 
     @classmethod
     async def get_policy_settings(
-        cls, session: AsyncSession, kadmin: AbstractKadmin,
+        cls,
+        session: AsyncSession,
+        kadmin: AbstractKadmin,
     ) -> "PasswordPolicySchema":
         """Get policy settings.
 
@@ -112,7 +119,9 @@ class PasswordPolicySchema(BaseModel):
         return cls.model_validate(policy, from_attributes=True)
 
     async def update_policy_settings(
-        self, session: AsyncSession, kadmin: AbstractKadmin,
+        self,
+        session: AsyncSession,
+        kadmin: AbstractKadmin,
     ) -> None:
         """Update policy.
 
@@ -131,7 +140,9 @@ class PasswordPolicySchema(BaseModel):
 
     @classmethod
     async def delete_policy_settings(
-        cls, session: AsyncSession, kadmin: AbstractKadmin,
+        cls,
+        session: AsyncSession,
+        kadmin: AbstractKadmin,
     ) -> "PasswordPolicySchema":
         """Reset (delete) default policy.
 
@@ -162,7 +173,8 @@ class PasswordPolicySchema(BaseModel):
 
     @staticmethod
     async def get_pwd_last_set(
-        session: AsyncSession, directory_id: int,
+        session: AsyncSession,
+        directory_id: int,
     ) -> Attribute:
         """Get pwdLastSet.
 
@@ -178,7 +190,9 @@ class PasswordPolicySchema(BaseModel):
         )
         if not plset:
             plset = Attribute(
-                directory_id=directory_id, name="pwdLastSet", value=ft_now(),
+                directory_id=directory_id,
+                name="pwdLastSet",
+                value=ft_now(),
             )
 
             session.add(plset)
@@ -237,7 +251,8 @@ class PasswordPolicySchema(BaseModel):
 
         if user is not None:
             history = islice(
-                reversed(user.password_history), self.password_history_length,
+                reversed(user.password_history),
+                self.password_history_length,
             )
 
         for pwd_hash in history:

--- a/app/ldap_protocol/server.py
+++ b/app/ldap_protocol/server.py
@@ -159,7 +159,8 @@ class PoolClientHandler:
             "certificates for public domains. "
             "Try deleting and recreating the `acme.json` file, "
             "or consider using a self-signed certificate "
-            "for local environments or closed networks.")
+            "for local environments or closed networks."
+        )
 
         if not os.path.exists("/certs/acme.json"):
             log.critical("Cannot load ACME file for MultiDirectory")
@@ -212,7 +213,7 @@ class PoolClientHandler:
             if len(data) >= bytes_length + 2:
                 value_length = 0
                 cont = bytes_length
-                for byte in data[2:2 + bytes_length]:
+                for byte in data[2 : 2 + bytes_length]:
                     cont -= 1
                     value_length += byte * (256**cont)
                 return value_length + 2 + bytes_length
@@ -310,7 +311,9 @@ class PoolClientHandler:
         log.info(f"\n{addr!r}: {msg.name}[{msg.message_id}]\n")
 
     async def _handle_single_response(
-        self, writer: asyncio.StreamWriter, container: AsyncContainer,
+        self,
+        writer: asyncio.StreamWriter,
+        container: AsyncContainer,
     ) -> None:
         """Get message from queue and handle it."""
         ldap_session: LDAPSession = await container.get(LDAPSession)
@@ -345,7 +348,10 @@ class PoolClientHandler:
                 raise RuntimeError(err) from err
 
     async def _wrap_response(
-        self, data: bytes, ldap_session: LDAPSession, protocol_op: int,
+        self,
+        data: bytes,
+        ldap_session: LDAPSession,
+        protocol_op: int,
     ) -> bytes:
         """Wrap response with GSSAPI security layer if needed.
 
@@ -362,16 +368,12 @@ class PoolClientHandler:
             GSSAPISL.INTEGRITY_PROTECTION,
             GSSAPISL.CONFIDENTIALITY,
         ):
-            encrypt = (
-                ldap_session.gssapi_security_layer == (
-                    GSSAPISL.CONFIDENTIALITY
-                )
+            encrypt = ldap_session.gssapi_security_layer == (
+                GSSAPISL.CONFIDENTIALITY
             )
-            wrap_data = (
-                ldap_session.gssapi_security_context.wrap(
-                    data,
-                    encrypt=encrypt,
-                )
+            wrap_data = ldap_session.gssapi_security_context.wrap(
+                data,
+                encrypt=encrypt,
             )
             sasl_buffer_length = len(wrap_data.message).to_bytes(4, "big")
 

--- a/app/ldap_protocol/server.py
+++ b/app/ldap_protocol/server.py
@@ -358,25 +358,24 @@ class PoolClientHandler:
             ldap_session.gssapi_authenticated
             and protocol_op != 1
             and ldap_session.gssapi_security_context
+        ) and ldap_session.gssapi_security_layer in (
+            GSSAPISL.INTEGRITY_PROTECTION,
+            GSSAPISL.CONFIDENTIALITY,
         ):
-            if ldap_session.gssapi_security_layer in (
-                GSSAPISL.INTEGRITY_PROTECTION,
-                GSSAPISL.CONFIDENTIALITY,
-            ):
-                encrypt = (
-                    ldap_session.gssapi_security_layer == (
-                        GSSAPISL.CONFIDENTIALITY
-                    )
+            encrypt = (
+                ldap_session.gssapi_security_layer == (
+                    GSSAPISL.CONFIDENTIALITY
                 )
-                wrap_data = (
-                    ldap_session.gssapi_security_context.wrap(
-                        data,
-                        encrypt=encrypt,
-                    )
+            )
+            wrap_data = (
+                ldap_session.gssapi_security_context.wrap(
+                    data,
+                    encrypt=encrypt,
                 )
-                sasl_buffer_length = len(wrap_data.message).to_bytes(4, "big")  # noqa
+            )
+            sasl_buffer_length = len(wrap_data.message).to_bytes(4, "big")
 
-                return sasl_buffer_length + wrap_data.message
+            return sasl_buffer_length + wrap_data.message
 
         return data
 
@@ -415,7 +414,7 @@ class PoolClientHandler:
             await server.serve_forever()
 
     @staticmethod
-    def log_addrs(server: asyncio.base_events.Server) -> None:  # noqa
+    def log_addrs(server: asyncio.base_events.Server) -> None:
         addrs = ", ".join(str(sock.getsockname()) for sock in server.sockets)
         log.info(f"Server on {addrs}")
 
@@ -423,8 +422,8 @@ class PoolClientHandler:
         """Run and log tcp server."""
         server = await self._get_server()
         log.info(
-            f'started {'DEBUG' if self.settings.DEBUG else 'PROD'} '
-            f'{'LDAPS' if self.settings.USE_CORE_TLS else 'LDAP'} server',
+            f"started {'DEBUG' if self.settings.DEBUG else 'PROD'} "
+            f"{'LDAPS' if self.settings.USE_CORE_TLS else 'LDAP'} server",
         )
 
         try:

--- a/app/ldap_protocol/session_storage.py
+++ b/app/ldap_protocol/session_storage.py
@@ -71,8 +71,7 @@ class SessionStorage(ABC):
 
     def get_user_agent_hash(self, user_agent: str) -> str:
         """Get user agent hash."""
-        return hashlib.blake2b(
-            user_agent.encode(), digest_size=6).hexdigest()
+        return hashlib.blake2b(user_agent.encode(), digest_size=6).hexdigest()
 
     def _get_id_hash(self, user_id: int) -> str:
         return (

--- a/app/ldap_protocol/session_storage.py
+++ b/app/ldap_protocol/session_storage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import hmac
 import json
@@ -263,7 +264,7 @@ class RedisSessionStorage(SessionStorage):
 
         retval = {}
 
-        for k, v in zip(keys, data):
+        for k, v in zip(keys, data, strict=False):
             if v is not None:
                 tmp = json.loads(v)
                 if k.startswith("ldap"):
@@ -485,10 +486,8 @@ class MemSessionStorage(SessionStorage):
         uid = int(tmp)
 
         keys = await self._get_user_keys(uid)
-        try:
+        with contextlib.suppress(KeyError):
             keys.remove(session_id)
-        except KeyError:
-            pass
 
         self._session_batch[self._get_id_hash(uid)] = list(keys)
         await self.delete([session_id])
@@ -568,4 +567,4 @@ class MemSessionStorage(SessionStorage):
         key = await self.create_session(uid, settings, extra_data=extra_data)
         await self.delete_user_session(session_id)
 
-        return key  # noqa: R504
+        return key

--- a/app/ldap_protocol/session_storage.py
+++ b/app/ldap_protocol/session_storage.py
@@ -75,8 +75,12 @@ class SessionStorage(ABC):
             user_agent.encode(), digest_size=6).hexdigest()
 
     def _get_id_hash(self, user_id: int) -> str:
-        return "keys:" + hashlib.blake2b(
-            str(user_id).encode(), digest_size=16).hexdigest()
+        return (
+            "keys:"
+            + hashlib.blake2b(
+                str(user_id).encode(), digest_size=16
+            ).hexdigest()
+        )
 
     def _generate_key(self) -> str:
         """Generate a new key for storing data in the storage.
@@ -324,7 +328,8 @@ class RedisSessionStorage(SessionStorage):
         :return str: jwt token
         """
         session_id, signature, data = self._generate_session_data(
-            uid, settings, extra_data)
+            uid, settings, extra_data
+        )
 
         await self._storage.set(session_id, json.dumps(data), ex=self.key_ttl)
         await self._storage.append(self._get_id_hash(uid), f"{session_id};")
@@ -336,7 +341,8 @@ class RedisSessionStorage(SessionStorage):
         return await self._storage.exists(session_id)
 
     async def create_ldap_session(
-            self, uid: int, key: str, data: dict) -> None:
+        self, uid: int, key: str, data: dict
+    ) -> None:
         """Create ldap session.
 
         :param int uid: user id
@@ -363,9 +369,7 @@ class RedisSessionStorage(SessionStorage):
         data = await self.get(session_id)
 
         issued = datetime.fromisoformat(data.get("issued"))  # type: ignore
-        return (
-            (datetime.now(timezone.utc) - issued).seconds > rekey_interval
-        )
+        return (datetime.now(timezone.utc) - issued).seconds > rekey_interval
 
     async def _rekey_session(self, session_id: str, settings: Settings) -> str:
         """Rekey session.
@@ -385,13 +389,14 @@ class RedisSessionStorage(SessionStorage):
         extra_data = data.copy()
         extra_data.pop("sign", None)
 
-        new_session_id, new_signature, new_data = (
-            self._generate_session_data(uid, settings, extra_data)
+        new_session_id, new_signature, new_data = self._generate_session_data(
+            uid, settings, extra_data
         )
 
         await self._storage.set(new_session_id, json.dumps(new_data), ex=ttl)
         await self._storage.append(
-            self._get_id_hash(uid), f"{new_session_id};")
+            self._get_id_hash(uid), f"{new_session_id};"
+        )
 
         await self.delete_user_session(session_id)
 
@@ -405,7 +410,8 @@ class RedisSessionStorage(SessionStorage):
         :return str: jwt token
         """
         lock = self._storage.lock(
-            self._get_lock_key(session_id), blocking_timeout=5)
+            self._get_lock_key(session_id), blocking_timeout=5
+        )
 
         async with lock:
             return await self._rekey_session(session_id, settings)
@@ -426,7 +432,8 @@ class MemSessionStorage(SessionStorage):
         return self._sessions[key]
 
     async def _set_data(
-            self, key: str, data: dict, expire: int | None) -> None:
+        self, key: str, data: dict, expire: int | None
+    ) -> None:
         """Set session data."""
         self._sessions[key] = data
 
@@ -509,7 +516,8 @@ class MemSessionStorage(SessionStorage):
         :return str: jwt token
         """
         session_id, signature, data = self._generate_session_data(
-            uid, settings, extra_data)
+            uid, settings, extra_data
+        )
 
         self._sessions[session_id] = data
         self._session_batch[self._get_id_hash(uid)].append(session_id)
@@ -521,7 +529,8 @@ class MemSessionStorage(SessionStorage):
         return session_id in self._sessions
 
     async def create_ldap_session(
-            self, uid: int, key: str, data: dict) -> None:
+        self, uid: int, key: str, data: dict
+    ) -> None:
         """Create ldap session.
 
         :param int uid: user id
@@ -543,9 +552,7 @@ class MemSessionStorage(SessionStorage):
         data = await self.get(session_id)
 
         issued = datetime.fromisoformat(data.get("issued"))  # type: ignore
-        return (
-            (datetime.now(timezone.utc) - issued).seconds > rekey_interval
-        )
+        return (datetime.now(timezone.utc) - issued).seconds > rekey_interval
 
     async def rekey_session(self, session_id: str, settings: Settings) -> str:
         """Rekey session.

--- a/app/ldap_protocol/user_account_control.py
+++ b/app/ldap_protocol/user_account_control.py
@@ -86,7 +86,7 @@ class UserAccountControlFlag(IntFlag):
         if uac_value == 0:
             return False
 
-        return False if uac_value & ~sum(flag.value for flag in cls) else True
+        return not uac_value & ~sum(flag.value for flag in cls)
 
 
 async def get_check_uac(

--- a/app/ldap_protocol/user_account_control.py
+++ b/app/ldap_protocol/user_account_control.py
@@ -99,14 +99,14 @@ async def get_check_uac(
     :return Callable: function to check given flag in current
         userAccountControl attribute
     """
-    query = (
-        select(Attribute)
-        .filter_by(directory_id=directory_id, name="userAccountControl")
+    query = select(Attribute).filter_by(
+        directory_id=directory_id, name="userAccountControl"
     )
     uac = await session.scalar(query)
 
     value: str = (
-        uac.value if uac is not None and uac.value is not None else "0")
+        uac.value if uac is not None and uac.value is not None else "0"
+    )
 
     def is_flag_true(flag: UserAccountControlFlag) -> bool:
         """Check given flag in current userAccountControl attribute.

--- a/app/ldap_protocol/user_account_control.py
+++ b/app/ldap_protocol/user_account_control.py
@@ -70,8 +70,7 @@ class UserAccountControlFlag(IntFlag):
 
     @classmethod
     def is_value_valid(cls, uac_value: str | int) -> bool:
-        """
-        Check all flags set in the userAccountControl value.
+        """Check all flags set in the userAccountControl value.
 
         :param int uac_value: userAccountControl attribute value
         :return: True if the value is valid (only known flags), False otherwise

--- a/app/ldap_protocol/utils/cte.py
+++ b/app/ldap_protocol/utils/cte.py
@@ -76,13 +76,13 @@ def find_members_recursive_cte(dn: str) -> CTE:
     In the case of a recursive search through the specified group1, the search
     result will be as follows: user1, user2, group2, user3, group3, user4.
     """
-    directory_hierarchy = (  # noqa: ECE001
+    directory_hierarchy = (
         select(Directory.id.label("directory_id"), Group.id.label("group_id"))
         .join(Directory.group)
         .select_from(Directory)
         .where(get_filter_from_path(dn))
     ).cte(recursive=True)
-    recursive_part = (  # noqa: ECE001
+    recursive_part = (
         select(
             DirectoryMembership.directory_id.label("directory_id"),
             Group.id.label("group_id"),
@@ -134,7 +134,7 @@ def find_root_group_recursive_cte(dn_list: list) -> CTE:
     result will be as follows: group1, group2, group3,
     user4.
     """
-    directory_hierarchy = (  # noqa: ECE001
+    directory_hierarchy = (
         select(
             Directory.id.label("directory_id"), Group.id.label("group_id"),
         )
@@ -142,7 +142,7 @@ def find_root_group_recursive_cte(dn_list: list) -> CTE:
         .join(Directory.group, isouter=True)
         .where(or_(*[get_filter_from_path(dn) for dn in dn_list]))
     ).cte(recursive=True)
-    recursive_part = (  # noqa: ECE001
+    recursive_part = (
         select(
             Group.directory_id.label("directory_id"),
             Group.id.label("group_id"),

--- a/app/ldap_protocol/utils/cte.py
+++ b/app/ldap_protocol/utils/cte.py
@@ -138,7 +138,8 @@ def find_root_group_recursive_cte(dn_list: list) -> CTE:
     """
     directory_hierarchy = (
         select(
-            Directory.id.label("directory_id"), Group.id.label("group_id"),
+            Directory.id.label("directory_id"),
+            Group.id.label("group_id"),
         )
         .select_from(Directory)
         .join(Directory.group, isouter=True)
@@ -161,7 +162,8 @@ def find_root_group_recursive_cte(dn_list: list) -> CTE:
 
 
 async def get_members_root_group(
-    dn: str, session: AsyncSession,
+    dn: str,
+    session: AsyncSession,
 ) -> list[Directory]:
     """Get all members root group by dn.
 
@@ -199,15 +201,13 @@ async def get_members_root_group(
     if not directories_ids:
         return []
 
-    query = (
-        select(Directory).where(
-            or_(
-                *[
-                    Directory.id == directory_id
-                    for directory_id in directories_ids
-                ],
-            ),
-        )
+    query = select(Directory).where(
+        or_(
+            *[
+                Directory.id == directory_id
+                for directory_id in directories_ids
+            ],
+        ),
     )
 
     retval = await session.scalars(query)

--- a/app/ldap_protocol/utils/cte.py
+++ b/app/ldap_protocol/utils/cte.py
@@ -68,13 +68,14 @@ def find_members_recursive_cte(dn: str) -> CTE:
     SELECT * FROM anon_1;
 
     Example:
-    --------
+    -------
     Group1 includes user1, user2, and group2.
     Group2 includes users user3 and group3.
     Group3 includes user4.
 
     In the case of a recursive search through the specified group1, the search
     result will be as follows: user1, user2, group2, user3, group3, user4.
+
     """
     directory_hierarchy = (
         select(Directory.id.label("directory_id"), Group.id.label("group_id"))
@@ -125,7 +126,7 @@ def find_root_group_recursive_cte(dn_list: list) -> CTE:
     SELECT * FROM anon_1;
 
     Example:
-    --------
+    -------
     Group1 includes user1, user2, and group2.
     Group2 includes users user3 and group3.
     Group3 includes user4.
@@ -133,6 +134,7 @@ def find_root_group_recursive_cte(dn_list: list) -> CTE:
     In the case of a recursive search through the specified user4, the search
     result will be as follows: group1, group2, group3,
     user4.
+
     """
     directory_hierarchy = (
         select(
@@ -164,7 +166,7 @@ async def get_members_root_group(
     """Get all members root group by dn.
 
     Example:
-    --------
+    -------
     Group1 includes user1, user2, and group2.
     Group2 includes users user3 and group3.
     Group3 includes user4.
@@ -172,6 +174,7 @@ async def get_members_root_group(
     In the case of a recursive search through the specified user4, the search
     result will be as follows: group1, user1, user2, group2, user3, group3,
     user4.
+
     """
     cte = find_root_group_recursive_cte([dn])
     result = await session.scalars(select(cte.c.directory_id))

--- a/app/ldap_protocol/utils/helpers.py
+++ b/app/ldap_protocol/utils/helpers.py
@@ -286,7 +286,9 @@ def string_to_sid(sid_string: str) -> bytes:
 
 
 def create_object_sid(
-    domain: Directory, rid: int, reserved: bool = False,
+    domain: Directory,
+    rid: int,
+    reserved: bool = False,
 ) -> str:
     """Generate the objectSid attribute for an object.
 
@@ -298,7 +300,7 @@ def create_object_sid(
                           the final RID
     :return str: the complete objectSid as a string
     """
-    return domain.object_sid + f"-{rid if reserved else 1000+rid}"
+    return domain.object_sid + f"-{rid if reserved else 1000 + rid}"
 
 
 def generate_domain_sid() -> str:

--- a/app/ldap_protocol/utils/queries.py
+++ b/app/ldap_protocol/utils/queries.py
@@ -146,7 +146,7 @@ async def check_kerberos_group(
     if user is None:
         return False
 
-    query = (  # noqa: ECE001
+    query = (
         select(Group)
         .join(Group.users)
         .join(Group.directory)

--- a/app/ldap_protocol/utils/queries.py
+++ b/app/ldap_protocol/utils/queries.py
@@ -3,6 +3,7 @@
 Copyright (c) 2024 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
+
 import time
 from datetime import datetime
 from typing import Iterator
@@ -67,7 +68,8 @@ async def get_user_by_upn(session: AsyncSession, upn: str) -> User | None:
     :return User | None: user
     """
     return await session.scalar(
-        select(User).where(User.user_principal_name.ilike(upn)))
+        select(User).where(User.user_principal_name.ilike(upn))
+    )
 
 
 async def get_directories(
@@ -211,7 +213,7 @@ async def get_dn_by_id(id_: int, session: AsyncSession) -> str:
     """Get dn by id.
 
     >>> await get_dn_by_id(0, session)
-    >>> 'cn=groups,dc=example,dc=com'
+    >>> "cn=groups,dc=example,dc=com"
     """
     query = select(Directory).filter(Directory.id == id_)
     retval = (await session.scalars(query)).one()
@@ -260,7 +262,8 @@ async def create_group(
     await session.flush()
 
     dir_.object_sid = create_object_sid(
-        base_dn_list[0], sid if sid else dir_.id)
+        base_dn_list[0], sid if sid else dir_.id
+    )
 
     await session.flush()
 
@@ -295,7 +298,8 @@ async def is_computer(directory_id: int, session: AsyncSession) -> bool:
         .where(
             Attribute.name.ilike("objectclass"),
             Attribute.value == "computer",
-            Attribute.directory_id == directory_id)
+            Attribute.directory_id == directory_id,
+        )
         .exists(),
     )
     return (await session.scalars(query)).one()
@@ -314,22 +318,25 @@ async def add_lock_and_expire_attributes(
     """
     now_with_tz = datetime.now(tz=tz)
     absolute_date = int(time.mktime(now_with_tz.timetuple()) / 86400)
-    session.add_all([
-        Attribute(
-            name="nsAccountLock",
-            value="true",
-            directory=directory,
-        ),
-        Attribute(
-            name="shadowExpire",
-            value=str(absolute_date),
-            directory=directory,
-        ),
-    ])
+    session.add_all(
+        [
+            Attribute(
+                name="nsAccountLock",
+                value="true",
+                directory=directory,
+            ),
+            Attribute(
+                name="shadowExpire",
+                value=str(absolute_date),
+                directory=directory,
+            ),
+        ]
+    )
 
 
 async def get_principal_directory(
-    session: AsyncSession, principal_name: str,
+    session: AsyncSession,
+    principal_name: str,
 ) -> Directory | None:
     """Fetch the principal's directory by principal name.
 

--- a/app/models.py
+++ b/app/models.py
@@ -73,7 +73,7 @@ class CatalogueSetting(Base):
 
     __tablename__ = "Settings"
 
-    id: Mapped[int] = mapped_column(primary_key=True)  # noqa
+    id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(nullable=False, index=True)
     value: Mapped[str] = mapped_column(nullable=False)
 
@@ -134,7 +134,7 @@ class Directory(Base):
 
     __tablename__ = "Directory"
 
-    id: Mapped[int] = mapped_column(primary_key=True)  # noqa: A003
+    id: Mapped[int] = mapped_column(primary_key=True)
 
     parent_id: Mapped[int] = mapped_column(
         "parentId",
@@ -300,7 +300,7 @@ class User(Base):
 
     __tablename__ = "Users"
 
-    id: Mapped[int] = mapped_column(primary_key=True)  # noqa: A003
+    id: Mapped[int] = mapped_column(primary_key=True)
 
     directory_id: Mapped[int] = mapped_column(
         "directoryId",
@@ -353,7 +353,7 @@ class User(Base):
         "homedirectory": "homeDirectory",
     }
 
-    password_history: Mapped[list[str]] = mapped_column(  # noqa TAE002
+    password_history: Mapped[list[str]] = mapped_column(
         MutableList.as_mutable(postgresql.ARRAY(String)),
         server_default="{}",
         nullable=False,
@@ -365,7 +365,7 @@ class User(Base):
         primaryjoin="User.directory_id == DirectoryMembership.directory_id",
         secondaryjoin="DirectoryMembership.group_id == Group.id",
         back_populates="users",
-        lazy='selectin',
+        lazy="selectin",
         cascade="all",
         passive_deletes=True,
         overlaps="group,groups,directory",
@@ -391,7 +391,7 @@ class User(Base):
         now = datetime.now(tz=timezone.utc)
         user_account_exp = self.account_exp.astimezone(timezone.utc)
 
-        return True if now > user_account_exp else False
+        return now > user_account_exp
 
 
 class Group(Base):
@@ -399,7 +399,7 @@ class Group(Base):
 
     __tablename__ = "Groups"
 
-    id: Mapped[int] = mapped_column(primary_key=True)  # noqa: A003
+    id: Mapped[int] = mapped_column(primary_key=True)
 
     directory_id: Mapped[int] = mapped_column(
         "directoryId",
@@ -490,7 +490,7 @@ class Attribute(Base):
         ),
     )
 
-    id: Mapped[int] = mapped_column(primary_key=True)  # noqa: A003
+    id: Mapped[int] = mapped_column(primary_key=True)
 
     directory_id: Mapped[int] = mapped_column(
         "directoryId",
@@ -520,7 +520,7 @@ class NetworkPolicy(Base):
 
     __tablename__ = "Policies"
 
-    id: Mapped[int] = mapped_column(primary_key=True)  # noqa: A003
+    id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(nullable=False, unique=True)
 
     raw: Mapped[dict | list] = mapped_column(postgresql.JSON, nullable=False)
@@ -566,7 +566,7 @@ class PasswordPolicy(Base):
 
     __tablename__ = "PasswordPolicies"
 
-    id: Mapped[int] = mapped_column(primary_key=True)  # noqa: A003
+    id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(
         String(255),
         nullable=False,
@@ -593,7 +593,7 @@ class AccessPolicy(Base):
 
     __tablename__ = "AccessPolicies"
 
-    id: Mapped[int] = mapped_column(primary_key=True)  # noqa: A003
+    id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
 
     can_read: Mapped[nbool]

--- a/app/models.py
+++ b/app/models.py
@@ -3,6 +3,7 @@
 Copyright (c) 2024 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
+
 from __future__ import annotations
 
 import enum
@@ -46,10 +47,12 @@ class Base(DeclarativeBase, AsyncAttrs):
 
 nbool = Annotated[bool, mapped_column(nullable=False)]
 tbool = Annotated[
-    bool, mapped_column(server_default=expression.true(), nullable=False),
+    bool,
+    mapped_column(server_default=expression.true(), nullable=False),
 ]
 fbool = Annotated[
-    bool, mapped_column(server_default=expression.false(), nullable=False),
+    bool,
+    mapped_column(server_default=expression.false(), nullable=False),
 ]
 
 UniqueConstraint.argument_for("postgresql", "nulls_not_distinct", None)
@@ -57,7 +60,9 @@ UniqueConstraint.argument_for("postgresql", "nulls_not_distinct", None)
 
 @compiles(UniqueConstraint, "postgresql")
 def compile_create_uc(
-    create: DDLElement, compiler: DDLCompiler, **kw: dict,
+    create: DDLElement,
+    compiler: DDLCompiler,
+    **kw: dict,
 ) -> str:
     """Add NULLS NOT DISTINCT if its in args."""
     stmt = compiler.visit_unique_constraint(create, **kw)
@@ -83,10 +88,12 @@ class DirectoryMembership(Base):
 
     __tablename__ = "DirectoryMemberships"
     group_id: Mapped[int] = mapped_column(
-        ForeignKey("Groups.id", ondelete="CASCADE"), primary_key=True)
+        ForeignKey("Groups.id", ondelete="CASCADE"), primary_key=True
+    )
 
     directory_id: Mapped[int] = mapped_column(
-        ForeignKey("Directory.id", ondelete="CASCADE"), primary_key=True)
+        ForeignKey("Directory.id", ondelete="CASCADE"), primary_key=True
+    )
 
 
 class PolicyMembership(Base):
@@ -94,9 +101,11 @@ class PolicyMembership(Base):
 
     __tablename__ = "PolicyMemberships"
     group_id: Mapped[int] = mapped_column(
-        ForeignKey("Groups.id", ondelete="CASCADE"), primary_key=True)
+        ForeignKey("Groups.id", ondelete="CASCADE"), primary_key=True
+    )
     policy_id: Mapped[int] = mapped_column(
-        ForeignKey("Policies.id", ondelete="CASCADE"), primary_key=True)
+        ForeignKey("Policies.id", ondelete="CASCADE"), primary_key=True
+    )
 
 
 class PolicyMFAMembership(Base):
@@ -104,9 +113,11 @@ class PolicyMFAMembership(Base):
 
     __tablename__ = "PolicyMFAMemberships"
     group_id: Mapped[int] = mapped_column(
-        ForeignKey("Groups.id", ondelete="CASCADE"), primary_key=True)
+        ForeignKey("Groups.id", ondelete="CASCADE"), primary_key=True
+    )
     policy_id: Mapped[int] = mapped_column(
-        ForeignKey("Policies.id", ondelete="CASCADE"), primary_key=True)
+        ForeignKey("Policies.id", ondelete="CASCADE"), primary_key=True
+    )
 
 
 class AccessPolicyMembership(Base):
@@ -114,9 +125,11 @@ class AccessPolicyMembership(Base):
 
     __tablename__ = "AccessPolicyMemberships"
     dir_id: Mapped[int] = mapped_column(
-        ForeignKey("Directory.id", ondelete="CASCADE"), primary_key=True)
+        ForeignKey("Directory.id", ondelete="CASCADE"), primary_key=True
+    )
     policy_id: Mapped[int] = mapped_column(
-        ForeignKey("AccessPolicies.id", ondelete="CASCADE"), primary_key=True)
+        ForeignKey("AccessPolicies.id", ondelete="CASCADE"), primary_key=True
+    )
 
 
 class GroupAccessPolicyMembership(Base):
@@ -124,9 +137,11 @@ class GroupAccessPolicyMembership(Base):
 
     __tablename__ = "GroupAccessPolicyMemberships"
     group_id: Mapped[int] = mapped_column(
-        ForeignKey("Groups.id", ondelete="CASCADE"), primary_key=True)
+        ForeignKey("Groups.id", ondelete="CASCADE"), primary_key=True
+    )
     policy_id: Mapped[int] = mapped_column(
-        ForeignKey("AccessPolicies.id", ondelete="CASCADE"), primary_key=True)
+        ForeignKey("AccessPolicies.id", ondelete="CASCADE"), primary_key=True
+    )
 
 
 class Directory(Base):
@@ -174,7 +189,8 @@ class Directory(Base):
     objectsid: Mapped[str] = synonym("object_sid")
 
     password_policy_id: Mapped[int] = mapped_column(
-        ForeignKey("PasswordPolicies.id"), nullable=True)
+        ForeignKey("PasswordPolicies.id"), nullable=True
+    )
 
     object_guid: Mapped[uuid.UUID] = mapped_column(
         "objectGUID",
@@ -185,7 +201,8 @@ class Directory(Base):
     objectguid: Mapped[str] = synonym("object_guid")
 
     path: Mapped[list[str]] = mapped_column(
-        postgresql.ARRAY(String), nullable=False, index=True)
+        postgresql.ARRAY(String), nullable=False, index=True
+    )
 
     attributes: Mapped[list[Attribute]] = relationship(
         "Attribute",
@@ -316,15 +333,20 @@ class User(Base):
     )
 
     sam_accout_name: Mapped[str] = mapped_column(
-        "sAMAccountName", nullable=False, unique=True,
+        "sAMAccountName",
+        nullable=False,
+        unique=True,
     )
     user_principal_name: Mapped[str] = mapped_column(
-        "userPrincipalName", nullable=False, unique=True,
+        "userPrincipalName",
+        nullable=False,
+        unique=True,
     )
 
     mail: Mapped[str | None] = mapped_column(String(255))
     display_name: Mapped[str | None] = mapped_column(
-        "displayName", nullable=True)
+        "displayName", nullable=True
+    )
     password: Mapped[str] = mapped_column(nullable=True)
 
     samaccountname: Mapped[str] = synonym("sam_accout_name")
@@ -334,9 +356,11 @@ class User(Base):
     accountexpires: Mapped[str] = synonym("account_exp")
 
     last_logon: Mapped[datetime | None] = mapped_column(
-        "lastLogon", DateTime(timezone=True))
+        "lastLogon", DateTime(timezone=True)
+    )
     account_exp: Mapped[datetime | None] = mapped_column(
-        "accountExpires", DateTime(timezone=True))
+        "accountExpires", DateTime(timezone=True)
+    )
 
     search_fields = {
         "mail": "mail",
@@ -503,7 +527,9 @@ class Attribute(Base):
     bvalue: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
 
     directory: Mapped[Directory] = relationship(
-        "Directory", back_populates="attributes", uselist=False,
+        "Directory",
+        back_populates="attributes",
+        uselist=False,
     )
 
 
@@ -535,7 +561,10 @@ class NetworkPolicy(Base):
     priority: Mapped[int] = mapped_column(nullable=False)
 
     priority_uc = UniqueConstraint(
-        "priority", name="priority_uc", deferrable=True, initially="DEFERRED",
+        "priority",
+        name="priority_uc",
+        deferrable=True,
+        initially="DEFERRED",
     )
 
     groups: Mapped[list[Group]] = relationship(
@@ -544,7 +573,9 @@ class NetworkPolicy(Base):
         back_populates="policies",
     )
     mfa_status: Mapped[MFAFlags] = mapped_column(
-        Enum(MFAFlags), server_default="DISABLED", nullable=False,
+        Enum(MFAFlags),
+        server_default="DISABLED",
+        nullable=False,
     )
 
     is_ldap: Mapped[tbool]
@@ -575,15 +606,19 @@ class PasswordPolicy(Base):
     )
 
     password_history_length: Mapped[int] = mapped_column(
-        nullable=False, server_default="4")
+        nullable=False, server_default="4"
+    )
     maximum_password_age_days: Mapped[int] = mapped_column(
-        nullable=False, server_default="0",
+        nullable=False,
+        server_default="0",
     )
     minimum_password_age_days: Mapped[int] = mapped_column(
-        nullable=False, server_default="0",
+        nullable=False,
+        server_default="0",
     )
     minimum_password_length: Mapped[int] = mapped_column(
-        nullable=False, server_default="7",
+        nullable=False,
+        server_default="7",
     )
     password_must_meet_complexity_requirements: Mapped[tbool]
 

--- a/app/multidirectory.py
+++ b/app/multidirectory.py
@@ -180,10 +180,10 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Run ldap or http")
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument('--ldap', action='store_true', help="Run ldap")
-    group.add_argument('--http', action='store_true', help="Run http")
-    group.add_argument('--shadow', action='store_true', help="Run http")
-    group.add_argument('--scheduler', action='store_true', help="Run tasks")
+    group.add_argument("--ldap", action="store_true", help="Run ldap")
+    group.add_argument("--http", action="store_true", help="Run http")
+    group.add_argument("--shadow", action="store_true", help="Run http")
+    group.add_argument("--scheduler", action="store_true", help="Run tasks")
 
     args = parser.parse_args()
 

--- a/app/schedule.py
+++ b/app/schedule.py
@@ -53,9 +53,11 @@ async def _schedule(
 
 def scheduler(settings: Settings) -> None:
     """Sript entrypoint."""
+
     async def runner(settings: Settings) -> None:
         container = make_async_container(
-            MainProvider(), context={Settings: settings},
+            MainProvider(),
+            context={Settings: settings},
         )
 
         async with asyncio.TaskGroup() as tg:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "MultiDirectory"
-version = "2.1.1"
+version = "2.0.1"
 description = ""
 authors = ["Mastermind-U <rex49513@gmail.com>"]
 readme = "README.md"
@@ -61,24 +61,6 @@ watchdog = "4.0.2"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.isort]
-known_first_party = [
-    "ldap_protocol",
-    "client",
-    "config",
-    "models",
-    "api",
-    "security",
-    "tests",
-    "web_app",
-    "ioc",
-    "schedule",
-    "extra",
-]
-include_trailing_comma = true
-line_length = 79
-multi_line_output = 3
-
 [tool.mypy]
 plugins = ["sqlalchemy.ext.mypy.plugin", "pydantic.mypy"]
 ignore_missing_imports = true
@@ -105,65 +87,119 @@ show_missing = true
 [tool.coverage.run]
 concurrency = ["thread", "gevent"]
 
+
+# RUFF
+# ruff check . --preview
+# ruff check . --fix --unsafe-fixes
+# ruff format .
 [tool.ruff]
-# Exclude a variety of commonly ignored directories.
-exclude = [
-    ".bzr",
-    ".direnv",
-    ".eggs",
-    ".git",
-    ".git-rewrite",
-    ".hg",
-    ".ipynb_checkpoints",
-    ".mypy_cache",
-    ".nox",
-    ".pants.d",
-    ".pyenv",
-    ".pytest_cache",
-    ".pytype",
-    ".ruff_cache",
-    ".svn",
-    ".tox",
-    ".venv",
-    ".vscode",
-    "__pypackages__",
-    "_build",
-    "buck-out",
-    "build",
-    "dist",
-    "node_modules",
-    "site-packages",
-    "venv",
-]
-
-line-length = 79
-indent-width = 4
-
 target-version = "py312"
+line-length = 79
+output-format = "grouped"
+unsafe-fixes = true
+
+[tool.ruff.format]
+docstring-code-format = true
+docstring-code-line-length = 79
+line-ending = "lf"
+skip-magic-trailing-comma = false  # default: false
 
 [tool.ruff.lint]
-# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
-# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
-# McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F"]
-ignore = []
+# Flake8 S101, I900, G004, IF100, S311, D301, E231
+# S101 - ???
+# I900 - ???
+# G004 - ???
+# IF100 - default done
+# S311 - ???
+# D301 - ???
+# E231 - ???
 
-# Allow fix for all enabled rules (when `--fix`) is provided.
+select = [
+    "F",  # Pyflakes. Must have
+    "E",  # pycodestyle (Error), check tool.ruff.lint.pycodestyle. Must have
+    "W",  # pycodestyle (Warnings), check tool.ruff.lint.pycodestyle
+    "C90",  # mccabe (max_complexity), check tool.ruff.lint.mccabe
+    "I",  # isort, check tool.ruff.lint.isort. Must have
+    "N",  # pep8-naming
+    # "D",  # pydocstyle, check tool.ruff.lint.pydocstyle TODO uncomment, ruff fix and fix error
+    "UP",  # pyupgrade, check tool.ruff.lint.pyupgrade. Must have
+    "ANN",  # flake8-annotations, check tool.ruff.lint.flake8-annotations
+    # "ASYNC",  # flake8-async TODO uncomment, ruff fix and fix error
+    "S",  # flake8-bandit
+    "B",  # flake8-bugbear. Must have
+    "COM",  # flake8-commas
+    # "CPY",  # flake8-copyright TODO uncomment, ruff fix and fix error
+    # "PIE",  # flake8-pie TODO uncomment, ruff fix and fix error
+    # "PYI",  # flake8-pyi TODO uncomment, ruff fix and fix error
+    # "Q",  # flake8-quotes TODO uncomment, ruff fix and fix error
+    # "RET",  # flake8-return TODO uncomment, ruff fix and fix error
+    # "SLF",  # flake8-self TODO uncomment, ruff fix and fix error
+    # "SIM",  # flake8-simplify. Must have TODO uncomment, ruff fix and fix error
+    # "TC",  # flake8-type-checking, check flake8-type-checking TODO does we need it? uncomment, ruff fix and fix error
+    # "ARG",  # flake8-unused-arguments TODO uncomment, ruff fix and fix error
+    # "TD",  # flake8-todos TODO uncomment, ruff fix and fix error
+    # "ERA",  # eradicate TODO uncomment, ruff fix and fix error
+    # "PGH",  # pygrep-hooks TODO does we need it? uncomment, ruff fix and fix error
+    # "PL",  # Pylint TODO uncomment, ruff fix and fix error
+    # "DOC",  # pydoclint TODO uncomment, ruff fix and fix error
+    # "RUF",  # Ruff-specific rules TODO uncomment, ruff fix and fix error
+    "RUF100" # TODO delete that and uncomment "RUF"-rule in lune up.
+]
+
+# Gradually remove all values marked 'TODO' and fix errors.
+ignore = [
+    "UP007",  # TODO delete that and fix all errors
+    "UP015",  # TODO delete that and fix all errors
+    "UP017",  # TODO delete that and fix all errors
+    "UP032",  # TODO delete that and fix all errors
+    "UP034",  # TODO delete that and fix all errors
+    "UP035",  # this is necessary. We allowed deprecated import
+    "UP037",  # TODO delete that and fix all errors
+    "UP040",  # TODO delete that and fix all errors
+    "ANN001",  # TODO delete that and fix all errors
+    "ANN002",  # this is necessary.
+    "ANN003",  # this is necessary.
+    "ANN401",  # TODO delete that and fix all errors
+    "S311",  # TODO delete that and fix all errors
+    "B904",  # this is necessary.
+    "COM812",  # this is necessary. Cause conflicts when used with the formatter
+    "TC001",  # this is necessary.
+    "TC002",  # this is necessary.
+    "TC003",  # this is necessary.
+]
+extend-select = []
+
 fixable = ["ALL"]
 unfixable = []
 
-# Allow unused variables when underscore-prefixed.
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+[tool.ruff.lint.per-file-ignores]
+"tests/*.py" = ["S"] # Ignore `S` rules for the `tests/` directory.
 
-[tool.ruff.format]
-# Like Black, use double quotes for strings.
-quote-style = "double"
+[tool.ruff.lint.mccabe]
+# 23 Complexity level is too high, need to reduce this level
+# or ignore it `# noqa: C901`.
+max-complexity = 23
 
-# Like Black, indent with spaces, rather than tabs.
-indent-style = "space"
+[tool.ruff.lint.isort]
+known-first-party = [
+    "ldap_protocol",
+    "client",
+    "config",
+    "models",
+    "api",
+    "security",
+    "tests",
+    "web_app",
+    "ioc",
+    "schedule",
+    "extra",
+]
+split-on-trailing-comma = false
+combine-as-imports = true
 
-# Like Black, respect magic trailing commas.
-skip-magic-trailing-comma = false
+[tool.ruff.lint.flake8-annotations]
+suppress-dummy-args = true
+suppress-none-returning = true
 
-# Like Black, automatically detect the appropriate line ending.
-line-ending = "auto"
+[tool.ruff.lint.flake8-type-checking]
+quote-annotations = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,6 +203,7 @@ unfixable = []
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*.py" = ["S101"] # Ignore `Flake8-bandit S101` rule for the `tests/` directory.
+"alembic/*.py" = ["I001"]
 
 [tool.ruff.lint.mccabe]
 # 23 Complexity level is too high, need to reduce this level

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,8 @@ select = [
     "C90",  # mccabe (max_complexity), check tool.ruff.lint.mccabe
     "I",  # isort, check tool.ruff.lint.isort. Must have
     "N",  # pep8-naming
-    # "D",  # pydocstyle, check tool.ruff.lint.pydocstyle TODO uncomment, ruff fix and fix error
+    "A",  # flake8 builtin-attribute-shadowing
+    "D",  # pydocstyle, check tool.ruff.lint.pydocstyle TODO uncomment, ruff fix and fix error
     "UP",  # pyupgrade, check tool.ruff.lint.pyupgrade. Must have
     "ANN",  # flake8-annotations, check tool.ruff.lint.flake8-annotations
     # "ASYNC",  # flake8-async TODO uncomment, ruff fix and fix error
@@ -160,11 +161,21 @@ select = [
     # "PL",  # Pylint TODO uncomment, ruff fix and fix error
     # "DOC",  # pydoclint TODO uncomment, ruff fix and fix error
     # "RUF",  # Ruff-specific rules TODO uncomment, ruff fix and fix error
-    "RUF100" # TODO delete that and uncomment "RUF"-rule in line up.
+    "RUF100", # TODO delete that and uncomment "RUF"-rule in line up.
 ]
 
 # Gradually remove all values marked 'TODO' and fix errors.
 ignore = [
+    "D101",  # TODO delete that and fix all errors
+    "D102",  # TODO delete that and fix all errors
+    "D103",  # TODO delete that and fix all errors
+    "D104",  # TODO delete that and fix all errors
+    "D105",  # TODO delete that and fix all errors
+    "D106",  # TODO delete that and fix all errors
+    "D107",  # TODO delete that and fix all errors
+    "D203",  # this is necessary. Conflict with `D211`
+    "D205",  # TODO delete that and fix all errors
+    "D213",  # this is necessary. Conflict with `D212`
     "UP007",  # TODO delete that and fix all errors
     "UP015",  # TODO delete that and fix all errors
     "UP017",  # TODO delete that and fix all errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ select = [
     # "CPY",  # flake8-copyright TODO uncomment, ruff fix and fix error
     # "PIE",  # flake8-pie TODO uncomment, ruff fix and fix error
     # "PYI",  # flake8-pyi TODO uncomment, ruff fix and fix error
-    "PT",
+    "PT",  # flake8-pytest
     "Q",  # flake8-quotes TODO uncomment, ruff fix and fix error
     # "RET",  # flake8-return TODO uncomment, ruff fix and fix error
     # "SLF",  # flake8-self TODO uncomment, ruff fix and fix error
@@ -183,7 +183,7 @@ ignore = [
     "TC001",  # this is necessary.
     "TC002",  # this is necessary.
     "TC003",  # this is necessary.
-    "SIM101",
+    "SIM101",  # Аналог simplify-boolean-expressions IF100
 ]
 extend-select = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,7 @@ max-complexity = 23
 
 [tool.ruff.lint.isort]
 known-first-party = [
+    "app",
     "ldap_protocol",
     "client",
     "config",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "MultiDirectory"
-version = "2.0.1"
+version = "2.1.1"
 description = ""
 authors = ["Mastermind-U <rex49513@gmail.com>"]
 readme = "README.md"
@@ -89,9 +89,13 @@ concurrency = ["thread", "gevent"]
 
 
 # RUFF
+# Ruff is a linter, not a type checker.
+#
+# commands:
 # ruff check . --preview
 # ruff check . --fix --unsafe-fixes
 # ruff format .
+
 [tool.ruff]
 target-version = "py312"
 line-length = 79
@@ -106,14 +110,26 @@ skip-magic-trailing-comma = false  # default: false
 
 [tool.ruff.lint]
 # Flake8 S101, I900, G004, IF100, S311, D301, E231
-# S101 - ???
-# I900 - ???
-# G004 - ???
-# IF100 - default done
-# S311 - ???
-# D301 - ???
-# E231 - ???
+# Для alembic предлагаю оставить включенным, только некоторые правила можно вырубить.
+# S101 - done. Использование assert в коде. Вырубил только в тестах
+# I900 - done. Это аналог RUF100. Проверка использования комментариев # noqa
+# G004 - done. Аналог S102. Предлагаю врубить. Проверка использования небезопасных методов и функций (например, eval, exec)
+# IF100 - done. Это аналог SIM101. Предлагаю врубить. Проверка использования if условий, которые могут быть упрощены
+# S311 - done. Это аналог S311. Вырубил.
+# D301 - done. Вырублены все D-rules. Мб включим когда-нибудь, а пока добавлю и закомментирую.
+# E231 - done. Это не надо вырубать.
 
+# Ruff contains flake8-awesome.
+# flake8-annotations -> ANN (Ruff)
+# flake8-bandit -> S (Ruff)
+# flake8-bugbear -> B (Ruff)
+# flake8-commas -> COM (Ruff)
+# flake8-docstrings -> D (Ruff)
+# flake8-isort -> I (Ruff)
+# flake8-pytest -> PT (Ruff)
+# flake8-quotes -> Q (Ruff)
+# flake8-simplify -> SIM (Ruff)
+# flake8-type-checking -> TC (Ruff)
 select = [
     "F",  # Pyflakes. Must have
     "E",  # pycodestyle (Error), check tool.ruff.lint.pycodestyle. Must have
@@ -131,11 +147,12 @@ select = [
     # "CPY",  # flake8-copyright TODO uncomment, ruff fix and fix error
     # "PIE",  # flake8-pie TODO uncomment, ruff fix and fix error
     # "PYI",  # flake8-pyi TODO uncomment, ruff fix and fix error
-    # "Q",  # flake8-quotes TODO uncomment, ruff fix and fix error
+    "PT",
+    "Q",  # flake8-quotes TODO uncomment, ruff fix and fix error
     # "RET",  # flake8-return TODO uncomment, ruff fix and fix error
     # "SLF",  # flake8-self TODO uncomment, ruff fix and fix error
-    # "SIM",  # flake8-simplify. Must have TODO uncomment, ruff fix and fix error
-    # "TC",  # flake8-type-checking, check flake8-type-checking TODO does we need it? uncomment, ruff fix and fix error
+    "SIM",  # flake8-simplify. Must have TODO uncomment, ruff fix and fix error
+    "TC",  # flake8-type-checking, check flake8-type-checking TODO does we need it? uncomment, ruff fix and fix error
     # "ARG",  # flake8-unused-arguments TODO uncomment, ruff fix and fix error
     # "TD",  # flake8-todos TODO uncomment, ruff fix and fix error
     # "ERA",  # eradicate TODO uncomment, ruff fix and fix error
@@ -143,7 +160,7 @@ select = [
     # "PL",  # Pylint TODO uncomment, ruff fix and fix error
     # "DOC",  # pydoclint TODO uncomment, ruff fix and fix error
     # "RUF",  # Ruff-specific rules TODO uncomment, ruff fix and fix error
-    "RUF100" # TODO delete that and uncomment "RUF"-rule in lune up.
+    "RUF100" # TODO delete that and uncomment "RUF"-rule in line up.
 ]
 
 # Gradually remove all values marked 'TODO' and fix errors.
@@ -160,7 +177,7 @@ ignore = [
     "ANN002",  # this is necessary.
     "ANN003",  # this is necessary.
     "ANN401",  # TODO delete that and fix all errors
-    "S311",  # TODO delete that and fix all errors
+    "S311",  # this is necessary.
     "B904",  # this is necessary.
     "COM812",  # this is necessary. Cause conflicts when used with the formatter
     "TC001",  # this is necessary.
@@ -173,7 +190,7 @@ fixable = ["ALL"]
 unfixable = []
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*.py" = ["S"] # Ignore `S` rules for the `tests/` directory.
+"tests/*.py" = ["S101"] # Ignore `Flake8-bandit S101` rule for the `tests/` directory.
 
 [tool.ruff.lint.mccabe]
 # 23 Complexity level is too high, need to reduce this level

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,7 @@ ignore = [
     "TC001",  # this is necessary.
     "TC002",  # this is necessary.
     "TC003",  # this is necessary.
+    "SIM101",
 ]
 extend-select = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ select = [
     "I",  # isort, check tool.ruff.lint.isort. Must have
     "N",  # pep8-naming
     "A",  # flake8 builtin-attribute-shadowing
-    "D",  # pydocstyle, check tool.ruff.lint.pydocstyle TODO uncomment, ruff fix and fix error
+    "D",  # pydocstyle, check tool.ruff.lint.pydocstyle
     "UP",  # pyupgrade, check tool.ruff.lint.pyupgrade. Must have
     "ANN",  # flake8-annotations, check tool.ruff.lint.flake8-annotations
     # "ASYNC",  # flake8-async TODO uncomment, ruff fix and fix error
@@ -149,11 +149,11 @@ select = [
     # "PIE",  # flake8-pie TODO uncomment, ruff fix and fix error
     # "PYI",  # flake8-pyi TODO uncomment, ruff fix and fix error
     "PT",  # flake8-pytest
-    "Q",  # flake8-quotes TODO uncomment, ruff fix and fix error
+    "Q",  # flake8-quotes
     # "RET",  # flake8-return TODO uncomment, ruff fix and fix error
     # "SLF",  # flake8-self TODO uncomment, ruff fix and fix error
-    "SIM",  # flake8-simplify. Must have TODO uncomment, ruff fix and fix error
-    "TC",  # flake8-type-checking, check flake8-type-checking TODO does we need it? uncomment, ruff fix and fix error
+    "SIM",  # flake8-simplify. Must have
+    "TC",  # flake8-type-checking, check flake8-type-checking
     # "ARG",  # flake8-unused-arguments TODO uncomment, ruff fix and fix error
     # "TD",  # flake8-todos TODO uncomment, ruff fix and fix error
     # "ERA",  # eradicate TODO uncomment, ruff fix and fix error
@@ -161,7 +161,7 @@ select = [
     # "PL",  # Pylint TODO uncomment, ruff fix and fix error
     # "DOC",  # pydoclint TODO uncomment, ruff fix and fix error
     # "RUF",  # Ruff-specific rules TODO uncomment, ruff fix and fix error
-    "RUF100", # TODO delete that and uncomment "RUF"-rule in line up.
+    "RUF100", # Ruff100-specific rule TODO delete that and uncomment "RUF"-rule in line up.
 ]
 
 # Gradually remove all values marked 'TODO' and fix errors.
@@ -194,7 +194,7 @@ ignore = [
     "TC001",  # this is necessary.
     "TC002",  # this is necessary.
     "TC003",  # this is necessary.
-    "SIM101",  # Аналог simplify-boolean-expressions IF100
+    "SIM101",  # analogue simplify-boolean-expressions IF100
 ]
 extend-select = []
 
@@ -203,16 +203,15 @@ unfixable = []
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*.py" = ["S101"] # Ignore `Flake8-bandit S101` rule for the `tests/` directory.
-"alembic/*.py" = ["I001"]
+"alembic/*.py" = ["I001"] # Ignore `Flake8-isort IO01` rule for the `alembic/` directory. It works incorrect in CI ruff test.
 
 [tool.ruff.lint.mccabe]
 # 23 Complexity level is too high, need to reduce this level
 # or ignore it `# noqa: C901`.
-max-complexity = 23
+max-complexity = 30
 
 [tool.ruff.lint.isort]
 known-first-party = [
-    "app",
     "ldap_protocol",
     "client",
     "config",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,18 +109,20 @@ class TestProvider(Provider):
         dns_manager.create_record = AsyncMock()
         dns_manager.update_record = AsyncMock()
         dns_manager.delete_record = AsyncMock()
-        dns_manager.get_all_records = AsyncMock(return_value=[
-            {
-                "record_type": "A",
-                "records": [
-                    {
-                        "record_name": "example.com",
-                        "record_value": "127.0.0.1",
-                        "ttl": 3600,
-                    },
-                ],
-            },
-        ])
+        dns_manager.get_all_records = AsyncMock(
+            return_value=[
+                {
+                    "record_type": "A",
+                    "records": [
+                        {
+                            "record_name": "example.com",
+                            "record_value": "127.0.0.1",
+                            "ttl": 3600,
+                        },
+                    ],
+                },
+            ]
+        )
         dns_manager.setup = AsyncMock()
 
         if not self._cached_dns_manager:
@@ -132,9 +134,11 @@ class TestProvider(Provider):
 
     @provide(scope=Scope.REQUEST, provides=DNSManagerSettings, cache=False)
     async def get_dns_mngr_settings(
-        self, session: AsyncSession,
+        self,
+        session: AsyncSession,
     ) -> AsyncIterator["DNSManagerSettings"]:
         """Get DNS manager's settings."""
+
         async def resolve() -> str:
             return "127.0.0.1"
 
@@ -149,7 +153,8 @@ class TestProvider(Provider):
 
     @provide(scope=Scope.APP, provides=async_sessionmaker[AsyncSession])
     def get_session_factory(
-        self, engine: AsyncEngine,
+        self,
+        engine: AsyncEngine,
     ) -> async_sessionmaker[AsyncSession]:
         """Create session factory."""
         return async_sessionmaker(
@@ -161,7 +166,8 @@ class TestProvider(Provider):
 
     @provide(scope=Scope.APP, cache=False)
     async def get_session(
-        self, engine: AsyncEngine,
+        self,
+        engine: AsyncEngine,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> AsyncIterator[AsyncSession]:
         """Get test session with a savepoint."""
@@ -193,7 +199,8 @@ class TestProvider(Provider):
 
     @provide(scope=Scope.SESSION)
     async def get_ldap_session(
-            self, storage: SessionStorage) -> AsyncIterator[LDAPSession]:
+        self, storage: SessionStorage
+    ) -> AsyncIterator[LDAPSession]:
         """Create ldap session."""
         yield LDAPSession(storage=storage)
         return
@@ -237,7 +244,8 @@ async def container(settings: Settings) -> AsyncIterator[AsyncContainer]:
         TestProvider(),
         MFACredsProvider(),
         context={Settings: settings},
-        start_scope=Scope.RUNTIME)
+        start_scope=Scope.RUNTIME,
+    )
     yield ctnr
     await ctnr.close()
 
@@ -322,8 +330,7 @@ async def setup_session(session: AsyncSession) -> None:
     await setup_enviroment(session, dn="md.test", data=TEST_DATA)
 
     domain_ex = await session.scalars(
-        select(Directory)
-        .filter(Directory.parent_id.is_(None)),
+        select(Directory).filter(Directory.parent_id.is_(None)),
     )
 
     domain = domain_ex.one()
@@ -343,7 +350,8 @@ async def setup_session(session: AsyncSession) -> None:
 
 @pytest_asyncio.fixture(scope="function")
 async def ldap_session(
-        container: AsyncContainer) -> AsyncIterator[LDAPSession]:
+    container: AsyncContainer,
+) -> AsyncIterator[LDAPSession]:
     """Yield empty session."""
     async with container(scope=Scope.SESSION) as container:
         yield await container.get(LDAPSession)
@@ -381,7 +389,7 @@ def _server(
 ) -> Generator:
     """Run server in background."""
     task = asyncio.ensure_future(handler.start(), loop=event_loop)
-    event_loop.run_until_complete(asyncio.sleep(.1))
+    event_loop.run_until_complete(asyncio.sleep(0.1))
     yield
     with suppress(asyncio.CancelledError):
         task.cancel()
@@ -391,7 +399,8 @@ def _server(
 def ldap_client(settings: Settings) -> ldap3.Connection:
     """Get ldap clinet without a creds."""
     return ldap3.Connection(
-        ldap3.Server(str(settings.HOST), settings.PORT, get_info="ALL"))
+        ldap3.Server(str(settings.HOST), settings.PORT, get_info="ALL")
+    )
 
 
 @pytest_asyncio.fixture(scope="function")
@@ -409,16 +418,18 @@ async def app(
 
 @pytest_asyncio.fixture(scope="function")
 async def unbound_http_client(
-        app: FastAPI) -> AsyncIterator[httpx.AsyncClient]:
+    app: FastAPI,
+) -> AsyncIterator[httpx.AsyncClient]:
     """Get async client for fastapi tests.
 
     :param FastAPI app: asgi app
     :yield Iterator[AsyncIterator[httpx.AsyncClient]]: yield client
     """
     async with httpx.AsyncClient(
-            transport=httpx.ASGITransport(app=app, root_path="/api"),
-            timeout=3,
-            base_url="http://test") as client:
+        transport=httpx.ASGITransport(app=app, root_path="/api"),
+        timeout=3,
+        base_url="http://test",
+    ) as client:
         yield client
 
 
@@ -435,8 +446,9 @@ async def http_client(
     :param None setup_session: just a fixture call
     :return httpx.AsyncClient: bound client with cookies
     """
-    response = await unbound_http_client.post("auth/", data={
-        "username": creds.un, "password": creds.pw})
+    response = await unbound_http_client.post(
+        "auth/", data={"username": creds.un, "password": creds.pw}
+    )
 
     assert response.status_code == 200
     assert unbound_http_client.cookies.get("id")
@@ -466,8 +478,9 @@ def _force_override_tls(settings: Settings) -> Iterator:
 
 
 @pytest_asyncio.fixture
-async def dns_manager(container: AsyncContainer)\
-        -> AsyncIterator[AbstractDNSManager]:
+async def dns_manager(
+    container: AsyncContainer,
+) -> AsyncIterator[AbstractDNSManager]:
     """Get DI DNS manager."""
     async with container(scope=Scope.REQUEST) as container:
         yield await container.get(AbstractDNSManager)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -261,7 +261,7 @@ async def kadmin(container: AsyncContainer) -> AsyncIterator[AbstractKadmin]:
 
 
 @pytest.fixture(scope="session")
-def event_loop() -> Generator:  # noqa: indirect usage
+def event_loop() -> Generator:
     loop = uvloop.new_event_loop()
     yield loop
     with suppress(asyncio.CancelledError, RuntimeError):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,9 @@ class TestProvider(Provider):
 
         ok_response = Mock()
         ok_response.status_code = 200
-        ok_response.aiter_bytes.return_value = map(bytes, zip(b'test_string'))
+        ok_response.aiter_bytes.return_value = map(
+            bytes, zip(b"test_string", strict=False)
+        )
 
         kadmin.setup = AsyncMock()
         kadmin.ktadd = AsyncMock(return_value=ok_response)
@@ -131,10 +133,10 @@ class TestProvider(Provider):
     @provide(scope=Scope.REQUEST, provides=DNSManagerSettings, cache=False)
     async def get_dns_mngr_settings(
         self, session: AsyncSession,
-    ) -> AsyncIterator['DNSManagerSettings']:
+    ) -> AsyncIterator["DNSManagerSettings"]:
         """Get DNS manager's settings."""
         async def resolve() -> str:
-            return '127.0.0.1'
+            return "127.0.0.1"
 
         resolver = resolve()
         yield await get_dns_manager_settings(session, resolver)
@@ -327,7 +329,7 @@ async def setup_session(session: AsyncSession) -> None:
     domain = domain_ex.one()
 
     await create_access_policy(
-        name='Root Access Policy',
+        name="Root Access Policy",
         can_add=True,
         can_modify=True,
         can_read=True,
@@ -400,7 +402,7 @@ async def app(
     """App creator fixture."""
     async with container(scope=Scope.APP) as container:
         app = _create_basic_app(settings)
-        app.include_router(shadow_router, prefix='/shadow')
+        app.include_router(shadow_router, prefix="/shadow")
         setup_dishka(container, app)
         yield app
 
@@ -414,7 +416,7 @@ async def unbound_http_client(
     :yield Iterator[AsyncIterator[httpx.AsyncClient]]: yield client
     """
     async with httpx.AsyncClient(
-            transport=httpx.ASGITransport(app=app, root_path='/api'),
+            transport=httpx.ASGITransport(app=app, root_path="/api"),
             timeout=3,
             base_url="http://test") as client:
         yield client
@@ -437,7 +439,7 @@ async def http_client(
         "username": creds.un, "password": creds.pw})
 
     assert response.status_code == 200
-    assert unbound_http_client.cookies.get('id')
+    assert unbound_http_client.cookies.get("id")
 
     return unbound_http_client
 
@@ -445,13 +447,13 @@ async def http_client(
 @pytest.fixture
 def creds(user: dict) -> TestCreds:
     """Get creds from test data."""
-    return TestCreds(user['sam_accout_name'], user['password'])
+    return TestCreds(user["sam_accout_name"], user["password"])
 
 
 @pytest.fixture
 def user() -> dict:
     """Get user data."""
-    return TEST_DATA[1]['children'][0]['organizationalPerson']  # type: ignore
+    return TEST_DATA[1]["children"][0]["organizationalPerson"]  # type: ignore
 
 
 @pytest.fixture

--- a/tests/test_api/test_auth/test_pwd_policy.py
+++ b/tests/test_api/test_auth/test_pwd_policy.py
@@ -12,7 +12,7 @@ from httpx import AsyncClient
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_policy_password(http_client: AsyncClient) -> None:
     """Test create policy."""
     policy_data = {
@@ -34,8 +34,8 @@ async def test_policy_password(http_client: AsyncClient) -> None:
     assert response.json() == policy_data
 
     changed_data = copy(policy_data)
-    changed_data['maximum_password_age_days'] = 80
-    changed_data['minimum_password_age_days'] = 30
+    changed_data["maximum_password_age_days"] = 80
+    changed_data["minimum_password_age_days"] = 30
 
     response = await http_client.put(
         "/password-policy",

--- a/tests/test_api/test_auth/test_router_mfa.py
+++ b/tests/test_api/test_auth/test_router_mfa.py
@@ -25,9 +25,9 @@ async def test_set_and_remove_mfa(
     response = await http_client.post(
         "/multifactor/setup",
         json={
-            'mfa_key': "123",
-            'mfa_secret': "123",
-            'is_ldap_scope': False,
+            "mfa_key": "123",
+            "mfa_secret": "123",
+            "is_ldap_scope": False,
         },
     )
 
@@ -50,7 +50,7 @@ async def test_set_and_remove_mfa(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_connect_mfa(
     http_client: httpx.AsyncClient,
     session: AsyncSession,
@@ -58,18 +58,18 @@ async def test_connect_mfa(
 ) -> None:
     """Test websocket mfa."""
     session.add(
-        CatalogueSetting(name='mfa_secret', value='123'),
+        CatalogueSetting(name="mfa_secret", value="123"),
     )
-    session.add(CatalogueSetting(name='mfa_key', value='123'))
+    session.add(CatalogueSetting(name="mfa_key", value="123"))
     await session.commit()
 
     redirect_url = "example.com"
 
     response = await http_client.post(
-        '/multifactor/connect',
-        data={'username': creds.un, 'password': creds.pw})
+        "/multifactor/connect",
+        data={"username": creds.un, "password": creds.pw})
 
-    assert response.json() == {'status': 'pending', 'message': redirect_url}
+    assert response.json() == {"status": "pending", "message": redirect_url}
 
     user = await authenticate_user(session, creds.un, creds.pw)
 
@@ -77,11 +77,11 @@ async def test_connect_mfa(
 
     exp = datetime.now() + timedelta(minutes=5)
 
-    token = jwt.encode({'aud': '123', "uid": user.id, "exp": exp}, '123')
+    token = jwt.encode({"aud": "123", "uid": user.id, "exp": exp}, "123")
 
     response = await http_client.post(
-        '/multifactor/create',
-        data={'accessToken': token}, follow_redirects=False)
+        "/multifactor/create",
+        data={"accessToken": token}, follow_redirects=False)
 
     assert response.status_code == 302
-    assert response.cookies.get('id')
+    assert response.cookies.get("id")

--- a/tests/test_api/test_auth/test_router_mfa.py
+++ b/tests/test_api/test_auth/test_router_mfa.py
@@ -19,8 +19,8 @@ from tests.conftest import TestCreds
 
 @pytest.mark.asyncio
 async def test_set_and_remove_mfa(
-        http_client: httpx.AsyncClient,
-        session: AsyncSession) -> None:
+    http_client: httpx.AsyncClient, session: AsyncSession
+) -> None:
     """Set mfa."""
     response = await http_client.post(
         "/multifactor/setup",
@@ -34,19 +34,23 @@ async def test_set_and_remove_mfa(
     assert response.json() is True
     assert response.status_code == 201
 
-    assert await session.scalar(select(CatalogueSetting).filter_by(
-        name="mfa_key", value="123"))
-    assert await session.scalar(select(CatalogueSetting).filter_by(
-        name="mfa_secret", value="123"))
+    assert await session.scalar(
+        select(CatalogueSetting).filter_by(name="mfa_key", value="123")
+    )
+    assert await session.scalar(
+        select(CatalogueSetting).filter_by(name="mfa_secret", value="123")
+    )
 
     response = await http_client.delete("/multifactor/keys?scope=http")
 
     assert response.status_code == 200
 
-    assert not await session.scalar(select(CatalogueSetting).filter_by(
-        name="mfa_key", value="123"))
-    assert not await session.scalar(select(CatalogueSetting).filter_by(
-        name="mfa_secret", value="123"))
+    assert not await session.scalar(
+        select(CatalogueSetting).filter_by(name="mfa_key", value="123")
+    )
+    assert not await session.scalar(
+        select(CatalogueSetting).filter_by(name="mfa_secret", value="123")
+    )
 
 
 @pytest.mark.asyncio
@@ -67,7 +71,8 @@ async def test_connect_mfa(
 
     response = await http_client.post(
         "/multifactor/connect",
-        data={"username": creds.un, "password": creds.pw})
+        data={"username": creds.un, "password": creds.pw},
+    )
 
     assert response.json() == {"status": "pending", "message": redirect_url}
 
@@ -81,7 +86,9 @@ async def test_connect_mfa(
 
     response = await http_client.post(
         "/multifactor/create",
-        data={"accessToken": token}, follow_redirects=False)
+        data={"accessToken": token},
+        follow_redirects=False,
+    )
 
     assert response.status_code == 302
     assert response.cookies.get("id")

--- a/tests/test_api/test_auth/test_sessions.py
+++ b/tests/test_api/test_auth/test_sessions.py
@@ -110,7 +110,8 @@ async def test_session_creation_ldap_bind_unbind(
     assert not await storage.get_user_sessions(user.id)
 
     result = await event_loop.run_in_executor(
-        None, ldap_client.rebind, creds.un, creds.pw)
+        None, ldap_client.rebind, creds.un, creds.pw
+    )
 
     assert result
     assert ldap_client.bound
@@ -133,8 +134,10 @@ async def test_session_creation_ldap_bind_unbind(
     except AssertionError:
         # in ~1% of cases session is not deleted because of ldap3 lib bug
         import warnings
+
         warnings.warn(
-            "Session was not deleted after ldap unbind.", RuntimeWarning, 2)
+            "Session was not deleted after ldap unbind.", RuntimeWarning, 2
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_api/test_main/conftest.py
+++ b/tests/test_api/test_main/conftest.py
@@ -118,7 +118,7 @@ async def adding_test_user(
     assert data["resultCode"] == LDAPCodes.SUCCESS
 
     async with AsyncClient(
-            transport=ASGITransport(app=app, root_path='/api'),
+            transport=ASGITransport(app=app, root_path="/api"),
             timeout=3,
             base_url="http://test") as client:
 
@@ -133,7 +133,7 @@ async def adding_test_user(
         assert auth.cookies.get("id")
 
 
-@pytest_asyncio.fixture(scope='function')
+@pytest_asyncio.fixture(scope="function")
 async def add_dns_settings(
     session: AsyncSession,
 ) -> None:

--- a/tests/test_api/test_main/conftest.py
+++ b/tests/test_api/test_main/conftest.py
@@ -118,10 +118,10 @@ async def adding_test_user(
     assert data["resultCode"] == LDAPCodes.SUCCESS
 
     async with AsyncClient(
-            transport=ASGITransport(app=app, root_path="/api"),
-            timeout=3,
-            base_url="http://test") as client:
-
+        transport=ASGITransport(app=app, root_path="/api"),
+        timeout=3,
+        base_url="http://test",
+    ) as client:
         auth = await client.post(
             "auth/",
             data={

--- a/tests/test_api/test_main/test_dns.py
+++ b/tests/test_api/test_main/test_dns.py
@@ -1,4 +1,5 @@
 """Test DNS service."""
+
 import pytest
 from httpx import AsyncClient
 from starlette import status
@@ -20,18 +21,16 @@ async def test_dns_create_record(
     response = await http_client.post(
         "/dns/record",
         json={
-         "record_name": hostname,
-         "record_value": ip,
-         "record_type": record_type,
-         "ttl": ttl,
+            "record_name": hostname,
+            "record_value": ip,
+            "record_type": record_type,
+            "ttl": ttl,
         },
     )
 
     dns_manager.create_record.assert_called()  # type: ignore
     assert (
-        dns_manager  # type: ignore
-        .create_record
-        .call_args.args
+        dns_manager.create_record.call_args.args  # type: ignore
     ) == (hostname, ip, record_type, int(ttl))
 
     assert response.status_code == status.HTTP_200_OK
@@ -51,9 +50,9 @@ async def test_dns_delete_record(
         "DELETE",
         "/dns/record",
         json={
-         "record_name": hostname,
-         "record_value": ip,
-         "record_type": record_type,
+            "record_name": hostname,
+            "record_value": ip,
+            "record_type": record_type,
         },
     )
 
@@ -80,10 +79,10 @@ async def test_dns_update_record(
         "PATCH",
         "/dns/record",
         json={
-         "record_name": hostname,
-         "record_value": ip,
-         "record_type": record_type,
-         "ttl": ttl,
+            "record_name": hostname,
+            "record_value": ip,
+            "record_type": record_type,
+            "ttl": ttl,
         },
     )
 
@@ -104,14 +103,18 @@ async def test_dns_get_all_records(http_client: AsyncClient) -> None:
     assert response.status_code == status.HTTP_200_OK
 
     data = response.json()
-    assert data == [{
-        "record_type": "A",
-        "records": [{
-            "record_name": "example.com",
-            "record_value": "127.0.0.1",
-            "ttl": 3600,
-        }],
-    }]
+    assert data == [
+        {
+            "record_type": "A",
+            "records": [
+                {
+                    "record_name": "example.com",
+                    "record_value": "127.0.0.1",
+                    "ttl": 3600,
+                }
+            ],
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_api/test_main/test_dns.py
+++ b/tests/test_api/test_main/test_dns.py
@@ -7,7 +7,7 @@ from ldap_protocol.dns import AbstractDNSManager, DNSManagerState
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_dns_create_record(
     http_client: AsyncClient,
     dns_manager: AbstractDNSManager,
@@ -38,7 +38,7 @@ async def test_dns_create_record(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_dns_delete_record(
     http_client: AsyncClient,
     dns_manager: AbstractDNSManager,
@@ -48,8 +48,8 @@ async def test_dns_delete_record(
     ip = "127.0.0.1"
     record_type = "A"
     response = await http_client.request(
-        'DELETE',
-        '/dns/record',
+        "DELETE",
+        "/dns/record",
         json={
          "record_name": hostname,
          "record_value": ip,
@@ -66,7 +66,7 @@ async def test_dns_delete_record(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_dns_update_record(
     http_client: AsyncClient,
     dns_manager: AbstractDNSManager,
@@ -77,8 +77,8 @@ async def test_dns_update_record(
     record_type = "A"
     ttl = 3600
     response = await http_client.request(
-        'PATCH',
-        '/dns/record',
+        "PATCH",
+        "/dns/record",
         json={
          "record_name": hostname,
          "record_value": ip,
@@ -96,10 +96,10 @@ async def test_dns_update_record(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_dns_get_all_records(http_client: AsyncClient) -> None:
     """DNS Manager get all records test."""
-    response = await http_client.get('/dns/record')
+    response = await http_client.get("/dns/record")
 
     assert response.status_code == status.HTTP_200_OK
 
@@ -115,7 +115,7 @@ async def test_dns_get_all_records(http_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_dns_setup_selfhosted(
     http_client: AsyncClient,
     dns_manager: AbstractDNSManager,
@@ -126,7 +126,7 @@ async def test_dns_setup_selfhosted(
     tsig_key = None
     dns_ip_address = None
     response = await http_client.post(
-        '/dns/setup',
+        "/dns/setup",
         json={
             "dns_status": dns_status,
             "domain": domain,
@@ -141,11 +141,11 @@ async def test_dns_setup_selfhosted(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('add_dns_settings')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("add_dns_settings")
+@pytest.mark.usefixtures("session")
 async def test_dns_get_status(http_client: AsyncClient) -> None:
     """DNS Manager get status test."""
-    response = await http_client.get('/dns/status')
+    response = await http_client.get("/dns/status")
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {

--- a/tests/test_api/test_main/test_kadmin.py
+++ b/tests/test_api/test_main/test_kadmin.py
@@ -25,7 +25,7 @@ def _create_test_user_data(
         "entry": "cn=ktest,dc=md,dc=test",
         "password": pw,
         "attributes": [
-            {"type": "mail", "vals": ['123@mil.com']},
+            {"type": "mail", "vals": ["123@mil.com"]},
             {"type": "objectClass", "vals": [
                 "user", "top", "person",
                 "organizationalPerson",
@@ -40,7 +40,7 @@ def _create_test_user_data(
             {"type": "uid", "vals": ["ktest"]},
             {"type": "homeDirectory", "vals": ["/home/ktest"]},
             {"type": "sAMAccountName", "vals": [name]},
-            {"type": "userPrincipalName", "vals": ['ktest']},
+            {"type": "userPrincipalName", "vals": ["ktest"]},
             {"type": "displayName", "vals": ["Kerberos Administrator"]},
             {"type": "userAccountControl", "vals": ["512"]},
         ]}
@@ -55,9 +55,9 @@ async def test_tree_creation(
     settings: Settings,
 ) -> None:
     """Test tree creation."""
-    krbadmin_pw = 'Password123'
-    response = await http_client.post('/kerberos/setup/tree', json={
-        "mail": '777@example.com',
+    krbadmin_pw = "Password123"
+    response = await http_client.post("/kerberos/setup/tree", json={
+        "mail": "777@example.com",
         "krbadmin_password": krbadmin_pw,
     })
 
@@ -78,11 +78,11 @@ async def test_tree_creation(
         },
     )
     assert response.json()[
-        'search_result'][0]['object_name'] == "ou=services,dc=md,dc=test"
+        "search_result"][0]["object_name"] == "ou=services,dc=md,dc=test"
 
     bind = MutePolicyBindRequest(
         version=0,
-        name='cn=krbadmin,ou=users,dc=md,dc=test',
+        name="cn=krbadmin,ou=users,dc=md,dc=test",
         AuthenticationChoice=SimpleAuthentication(password=krbadmin_pw),
     )
 
@@ -92,26 +92,26 @@ async def test_tree_creation(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_tree_collision(http_client: AsyncClient) -> None:
     """Test tree collision double creation."""
-    response = await http_client.post('/kerberos/setup/tree', json={
-        "mail": '777@example.com',
-        "krbadmin_password": 'Password123',
+    response = await http_client.post("/kerberos/setup/tree", json={
+        "mail": "777@example.com",
+        "krbadmin_password": "Password123",
     })
 
     assert response.status_code == status.HTTP_200_OK
 
-    response = await http_client.post('/kerberos/setup/tree', json={
-        "mail": '777@example.com',
-        "krbadmin_password": 'Password123',
+    response = await http_client.post("/kerberos/setup/tree", json={
+        "mail": "777@example.com",
+        "krbadmin_password": "Password123",
     })
 
     assert response.status_code == status.HTTP_409_CONFLICT
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_setup_call(
     http_client: AsyncClient,
     kadmin: Mock,
@@ -122,37 +122,37 @@ async def test_setup_call(
     :param AsyncClient http_client: http cl
     :param LDAPSession ldap_session: ldap
     """
-    response = await http_client.post('/kerberos/setup', json={
-        "krbadmin_password": 'Password123',
+    response = await http_client.post("/kerberos/setup", json={
+        "krbadmin_password": "Password123",
         "admin_password": creds.pw,
-        "stash_password": 'Password123',
+        "stash_password": "Password123",
     })
 
     assert response.status_code == status.HTTP_200_OK
 
     kadmin.setup.assert_called()
 
-    krb_doc = kadmin.setup.call_args.kwargs.pop('krb5_config').encode()
-    kdc_doc = kadmin.setup.call_args.kwargs.pop('kdc_config').encode()
+    krb_doc = kadmin.setup.call_args.kwargs.pop("krb5_config").encode()
+    kdc_doc = kadmin.setup.call_args.kwargs.pop("kdc_config").encode()
 
     # NOTE: Asserting documents integrity, tests template rendering
-    assert blake2b(krb_doc, digest_size=8).hexdigest() == '84d7b6b78bca55fb'
-    assert blake2b(kdc_doc, digest_size=8).hexdigest() == '79e43649d34fe577'
+    assert blake2b(krb_doc, digest_size=8).hexdigest() == "84d7b6b78bca55fb"
+    assert blake2b(kdc_doc, digest_size=8).hexdigest() == "79e43649d34fe577"
 
     assert kadmin.setup.call_args.kwargs == {
-        'domain': 'md.test',
-        'admin_dn': 'cn=user0,ou=users,dc=md,dc=test',
-        'services_dn': 'ou=services,dc=md,dc=test',
-        'krbadmin_dn': 'cn=krbadmin,ou=users,dc=md,dc=test',
-        'krbadmin_password': 'Password123',
-        'ldap_keytab_path': '/LDAP_keytab/ldap.keytab',
-        'admin_password': creds.pw,
-        'stash_password': 'Password123',
+        "domain": "md.test",
+        "admin_dn": "cn=user0,ou=users,dc=md,dc=test",
+        "services_dn": "ou=services,dc=md,dc=test",
+        "krbadmin_dn": "cn=krbadmin,ou=users,dc=md,dc=test",
+        "krbadmin_password": "Password123",
+        "ldap_keytab_path": "/LDAP_keytab/ldap.keytab",
+        "admin_password": creds.pw,
+        "stash_password": "Password123",
     }
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_status_change(
     http_client: AsyncClient,
     creds: TestCreds,
@@ -163,23 +163,23 @@ async def test_status_change(
     :param LDAPSession ldap_session: ldap
     """
     response = await http_client.get(
-        '/kerberos/status')
+        "/kerberos/status")
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == KerberosState.NOT_CONFIGURED
 
-    await http_client.post('/kerberos/setup', json={
-        "krbadmin_password": 'Password123',
+    await http_client.post("/kerberos/setup", json={
+        "krbadmin_password": "Password123",
         "admin_password": creds.pw,
-        "stash_password": 'Password123',
+        "stash_password": "Password123",
     })
 
     response = await http_client.get(
-        '/kerberos/status')
+        "/kerberos/status")
     assert response.json() == KerberosState.WAITING_FOR_RELOAD
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_ktadd(
     http_client: AsyncClient,
     kadmin: AbstractKadmin,
@@ -189,21 +189,21 @@ async def test_ktadd(
     :param AsyncClient http_client: http cl
     :param LDAPSession ldap_session: ldap
     """
-    names = ['test1', 'test2']
-    response = await http_client.post('/kerberos/ktadd', json=names)
+    names = ["test1", "test2"]
+    response = await http_client.post("/kerberos/ktadd", json=names)
 
     kadmin.ktadd.assert_called()  # type: ignore
     assert kadmin.ktadd.call_args.args[0] == names  # type: ignore
 
     assert response.status_code == status.HTTP_200_OK
-    assert response.content == b'test_string'
+    assert response.content == b"test_string"
     assert response.headers[
-        'Content-Disposition'] == 'attachment; filename="krb5.keytab"'
-    assert response.headers['content-type'] == 'application/txt'
+        "Content-Disposition"] == 'attachment; filename="krb5.keytab"'
+    assert response.headers["content-type"] == "application/txt"
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_ktadd_404(
     http_client: AsyncClient,
     kadmin: AbstractKadmin,
@@ -215,14 +215,14 @@ async def test_ktadd_404(
     """
     kadmin.ktadd.side_effect = KRBAPIError()  # type: ignore
 
-    names = ['test1', 'test2']
-    response = await http_client.post('/kerberos/ktadd', json=names)
+    names = ["test1", "test2"]
+    response = await http_client.post("/kerberos/ktadd", json=names)
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_ldap_add(
     http_client: AsyncClient,
     kadmin: AbstractKadmin,
@@ -232,8 +232,8 @@ async def test_ldap_add(
     :param AsyncClient http_client: http
     :param TestKadminClient kadmin: kadmin
     """
-    san = 'ktest'
-    pw = 'Password123'
+    san = "ktest"
+    pw = "Password123"
 
     response = await http_client.post(
         "/entry/add",
@@ -244,7 +244,7 @@ async def test_ldap_add(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_ldap_kadmin_delete_user(
     http_client: AsyncClient,
     kadmin: AbstractKadmin,
@@ -252,7 +252,7 @@ async def test_ldap_kadmin_delete_user(
     """Test API for delete object."""
     await http_client.post(
         "/entry/add",
-        json=_create_test_user_data('ktest', 'Password123'))
+        json=_create_test_user_data("ktest", "Password123"))
 
     response = await http_client.request(
         "delete", "/entry/delete",
@@ -261,13 +261,13 @@ async def test_ldap_kadmin_delete_user(
 
     data = response.json()
 
-    assert data.get('resultCode') == LDAPCodes.SUCCESS
+    assert data.get("resultCode") == LDAPCodes.SUCCESS
 
     assert kadmin.del_principal.call_args.args[0] == "ktest"  # type: ignore
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_ldap_kadmin_delete_computer(
     http_client: AsyncClient,
     kadmin: AbstractKadmin,
@@ -289,9 +289,9 @@ async def test_ldap_kadmin_delete_computer(
 
     data = response.json()
 
-    assert data.get('resultCode') == LDAPCodes.SUCCESS
+    assert data.get("resultCode") == LDAPCodes.SUCCESS
     principal = kadmin.del_principal.call_args.args[0]  # type: ignore
-    assert principal == 'host/ktest.md.test'
+    assert principal == "host/ktest.md.test"
 
 
 @pytest.mark.asyncio
@@ -301,16 +301,16 @@ async def test_bind_create_user(
     settings: Settings,
 ) -> None:
     """Test bind create user."""
-    san = 'ktest'
-    pw = 'Password123'
+    san = "ktest"
+    pw = "Password123"
 
     await http_client.post("/entry/add", json=_create_test_user_data(san, pw))
 
     proc = await asyncio.create_subprocess_exec(
-        'ldapwhoami', '-x',
-        '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-        '-D', san,
-        '-w', pw,
+        "ldapwhoami", "-x",
+        "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D", san,
+        "-w", pw,
     )
 
     assert await proc.wait() == 0
@@ -319,9 +319,9 @@ async def test_bind_create_user(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
-@pytest.mark.usefixtures('_force_override_tls')
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
+@pytest.mark.usefixtures("_force_override_tls")
 async def test_extended_pw_change_call(
     event_loop: asyncio.BaseEventLoop,
     ldap_client: Connection,
@@ -338,7 +338,7 @@ async def test_extended_pw_change_call(
 
     result = await event_loop.run_in_executor(
         None,
-        partial(  # noqa: S106
+        partial(
             ldap_client.extend.standard.modify_password,
             old_password=password,
             new_password=new_test_password,
@@ -347,11 +347,11 @@ async def test_extended_pw_change_call(
     assert result
     kadmin_args = (
         kadmin.create_or_update_principal_pw.call_args.args)  # type: ignore
-    assert kadmin_args == ('user0', new_test_password)
+    assert kadmin_args == ("user0", new_test_password)
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_add_princ(
     http_client: AsyncClient,
     kadmin: AbstractKadmin,
@@ -362,7 +362,7 @@ async def test_add_princ(
     :param LDAPSession ldap_session: ldap
     """
     response = await http_client.post(
-        '/kerberos/principal/add',
+        "/kerberos/principal/add",
         json={
             "primary": "host",
             "instance": "12345",
@@ -374,7 +374,7 @@ async def test_add_princ(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_rename_princ(
     http_client: AsyncClient,
     kadmin: AbstractKadmin,
@@ -385,7 +385,7 @@ async def test_rename_princ(
     :param LDAPSession ldap_session: ldap
     """
     response = await http_client.patch(
-        '/kerberos/principal/rename',
+        "/kerberos/principal/rename",
         json={
             "principal_name": "name",
             "principal_new_name": "nname",
@@ -397,7 +397,7 @@ async def test_rename_princ(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_change_princ(
     http_client: AsyncClient,
     kadmin: AbstractKadmin,
@@ -408,7 +408,7 @@ async def test_change_princ(
     :param LDAPSession ldap_session: ldap
     """
     response = await http_client.patch(
-        '/kerberos/principal/reset',
+        "/kerberos/principal/reset",
         json={
             "principal_name": "name",
             "new_password": "pw123",
@@ -421,7 +421,7 @@ async def test_change_princ(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_delete_princ(
     http_client: AsyncClient,
     kadmin: AbstractKadmin,
@@ -433,7 +433,7 @@ async def test_delete_princ(
     """
     response = await http_client.request(
         "delete",
-        '/kerberos/principal/delete',
+        "/kerberos/principal/delete",
         json={"principal_name": "name"},
     )
     assert response.status_code == status.HTTP_200_OK
@@ -441,29 +441,29 @@ async def test_delete_princ(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("session")
+@pytest.mark.usefixtures("setup_session")
 async def test_admin_incorrect_pw_setup(http_client: AsyncClient) -> None:
     """Test setup args.
 
     :param AsyncClient http_client: http cl
     :param LDAPSession ldap_session: ldap
     """
-    response = await http_client.get('/kerberos/status')
+    response = await http_client.get("/kerberos/status")
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == KerberosState.NOT_CONFIGURED
 
-    response = await http_client.post('/kerberos/setup', json={
-        "krbadmin_password": 'Password123',
-        "admin_password": '----',
-        "stash_password": 'Password123',
+    response = await http_client.post("/kerberos/setup", json={
+        "krbadmin_password": "Password123",
+        "admin_password": "----",
+        "stash_password": "Password123",
     })
     data = response.json()
-    assert data['detail'] == 'Incorrect password'
+    assert data["detail"] == "Incorrect password"
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_api_update_password(
     http_client: AsyncClient,
     kadmin: AbstractKadmin,
@@ -479,7 +479,7 @@ async def test_api_update_password(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_update_password(
     http_client: AsyncClient,
     kadmin: AbstractKadmin,

--- a/tests/test_api/test_main/test_multifactor.py
+++ b/tests/test_api/test_main/test_multifactor.py
@@ -10,7 +10,7 @@ from ldap_protocol.multifactor import MultifactorAPI
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 @pytest.mark.parametrize(
     (
         "mock_post_side_effect",

--- a/tests/test_api/test_main/test_multifactor.py
+++ b/tests/test_api/test_main/test_multifactor.py
@@ -21,43 +21,46 @@ from ldap_protocol.multifactor import MultifactorAPI
         # 1. httpx.ConnectTimeout => raise MFAConnectError
         (
             httpx.ConnectTimeout("Connection timed out"),
-            True, MultifactorAPI.MFAConnectError,
+            True,
+            MultifactorAPI.MFAConnectError,
         ),
-
         # 2. httpx.ReadTimeout => False
         (
             httpx.ReadTimeout("Read timed out"),
-            False, None,
+            False,
+            None,
         ),
-
         # 3. status_code=401 => raise MFAMissconfiguredError
         (
             httpx.Response(status_code=401),
-            True, MultifactorAPI.MFAMissconfiguredError,
+            True,
+            MultifactorAPI.MFAMissconfiguredError,
         ),
-
         # 4. status_code=500 => raise MultifactorError
         (
             httpx.Response(status_code=500),
-            True, MultifactorAPI.MultifactorError,
+            True,
+            MultifactorAPI.MultifactorError,
         ),
-
         # 5. status_code=200, 'model.status' != "Granted" => False
         (
             httpx.Response(
                 status_code=200,
                 json={"model": {"status": "Denied"}},
                 request=httpx.Request("POST", ""),
-            ), False, None,
+            ),
+            False,
+            None,
         ),
-
         # 6. status_code=200, 'model.status' == "Granted" => True
         (
             httpx.Response(
                 status_code=200,
                 json={"model": {"status": "Granted"}},
                 request=httpx.Request("POST", ""),
-            ), True, None,
+            ),
+            True,
+            None,
         ),
     ],
 )
@@ -81,6 +84,7 @@ async def test_ldap_validate_mfa(
             await mfa_api.ldap_validate_mfa("user", "password")
     else:
         result = await mfa_api.ldap_validate_mfa(
-            "user", "password",
+            "user",
+            "password",
         )
         assert result == expected_result

--- a/tests/test_api/test_main/test_router/test_add.py
+++ b/tests/test_api/test_main/test_router/test_add.py
@@ -12,7 +12,7 @@ from ldap_protocol.user_account_control import UserAccountControlFlag
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_api_correct_add(http_client: AsyncClient) -> None:
     """Test api correct add."""
     response = await http_client.post(
@@ -47,12 +47,12 @@ async def test_api_correct_add(http_client: AsyncClient) -> None:
 
     assert isinstance(data, dict)
     assert response.status_code == status.HTTP_200_OK
-    assert data.get('resultCode') == LDAPCodes.SUCCESS
-    assert data.get('errorMessage') == ''
+    assert data.get("resultCode") == LDAPCodes.SUCCESS
+    assert data.get("errorMessage") == ""
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_api_add_computer(http_client: AsyncClient) -> None:
     """Test api correct add computer."""
     new_entry = "cn=PC,dc=md,dc=test"
@@ -96,19 +96,19 @@ async def test_api_add_computer(http_client: AsyncClient) -> None:
     )
     data = response.json()
 
-    assert data['search_result'][0]['object_name'] == new_entry
+    assert data["search_result"][0]["object_name"] == new_entry
 
-    for attr in data['search_result'][0]['partial_attributes']:
-        if attr['type'] == 'userAccountControl':
-            assert int(attr['vals'][0]) &\
+    for attr in data["search_result"][0]["partial_attributes"]:
+        if attr["type"] == "userAccountControl":
+            assert int(attr["vals"][0]) &\
                 UserAccountControlFlag.WORKSTATION_TRUST_ACCOUNT
             break
     else:
-        raise Exception('Computer without userAccountControl')
+        raise Exception("Computer without userAccountControl")
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_api_correct_add_double_member_of(
         http_client: AsyncClient) -> None:
     """Test api correct add a group with a register.
@@ -136,11 +136,11 @@ async def test_api_correct_add_double_member_of(
                 },
                 {
                     "type": "groupType",
-                    "vals": ['-2147483646'],
+                    "vals": ["-2147483646"],
                 },
                 {
                     "type": "instanceType",
-                    "vals": ['4'],
+                    "vals": ["4"],
                 },
             ],
         },
@@ -148,7 +148,7 @@ async def test_api_correct_add_double_member_of(
     data = response.json()
 
     assert response.status_code == status.HTTP_200_OK
-    assert data.get('resultCode') == LDAPCodes.SUCCESS
+    assert data.get("resultCode") == LDAPCodes.SUCCESS
 
     response = await http_client.post(
         "entry/search",
@@ -166,10 +166,10 @@ async def test_api_correct_add_double_member_of(
     )
     data = response.json()
 
-    assert data['search_result'][0]['object_name'] == new_group
+    assert data["search_result"][0]["object_name"] == new_group
 
-    for attr in data['search_result'][0]['partial_attributes']:
-        assert attr['type'] != 'memberOf'
+    for attr in data["search_result"][0]["partial_attributes"]:
+        assert attr["type"] != "memberOf"
 
     response = await http_client.post(
         "/entry/add",
@@ -219,7 +219,7 @@ async def test_api_correct_add_double_member_of(
     data = response.json()
 
     assert response.status_code == status.HTTP_200_OK
-    assert data.get('resultCode') == LDAPCodes.SUCCESS
+    assert data.get("resultCode") == LDAPCodes.SUCCESS
 
     response = await http_client.post(
         "entry/search",
@@ -238,28 +238,28 @@ async def test_api_correct_add_double_member_of(
     data = response.json()
 
     assert response.status_code == status.HTTP_200_OK
-    assert data.get('resultCode') == LDAPCodes.SUCCESS
-    assert data['search_result'][0]['object_name'] == user
+    assert data.get("resultCode") == LDAPCodes.SUCCESS
+    assert data["search_result"][0]["object_name"] == user
 
     created_groups = groups + ["cn=domain users,cn=groups,dc=md,dc=test"]
 
-    for attr in data['search_result'][0]['partial_attributes']:
-        if attr['type'] == 'memberOf':
-            assert all(group in created_groups for group in attr['vals'])
+    for attr in data["search_result"][0]["partial_attributes"]:
+        if attr["type"] == "memberOf":
+            assert all(group in created_groups for group in attr["vals"])
             break
     else:
-        raise Exception('memberOf not found')
+        raise Exception("memberOf not found")
 
-    for attr in data['search_result'][0]['partial_attributes']:
-        if attr['type'] == 'userAccountControl':
-            assert attr['vals'][0] == "514"
+    for attr in data["search_result"][0]["partial_attributes"]:
+        if attr["type"] == "userAccountControl":
+            assert attr["vals"][0] == "514"
             break
     else:
-        raise Exception('userAccountControl not found')
+        raise Exception("userAccountControl not found")
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_api_add_user_inccorect_uac(
         http_client: AsyncClient) -> None:
     """Test api add."""
@@ -310,7 +310,7 @@ async def test_api_add_user_inccorect_uac(
     data = response.json()
 
     assert response.status_code == status.HTTP_200_OK
-    assert data.get('resultCode') == LDAPCodes.SUCCESS
+    assert data.get("resultCode") == LDAPCodes.SUCCESS
 
     response = await http_client.post(
         "entry/search",
@@ -329,24 +329,24 @@ async def test_api_add_user_inccorect_uac(
     data = response.json()
 
     assert response.status_code == status.HTTP_200_OK
-    assert data.get('resultCode') == LDAPCodes.SUCCESS
-    assert data['search_result'][0]['object_name'] == user
+    assert data.get("resultCode") == LDAPCodes.SUCCESS
+    assert data["search_result"][0]["object_name"] == user
 
-    for attr in data['search_result'][0]['partial_attributes']:
-        if attr['type'] == 'userAccountControl':
-            assert attr['vals'][0] == "512"
+    for attr in data["search_result"][0]["partial_attributes"]:
+        if attr["type"] == "userAccountControl":
+            assert attr["vals"][0] == "512"
             break
     else:
-        raise Exception('userAccountControl not found')
+        raise Exception("userAccountControl not found")
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_api_add_non_auth_user(unbound_http_client: AsyncClient) -> None:
     """Test API add for unauthorized user."""
     unbound_http_client.cookies.set(
-        'id', "09e67421-2f92-8ddc-494108a6e04f")
+        "id", "09e67421-2f92-8ddc-494108a6e04f")
     response = await unbound_http_client.post(
         "/entry/add",
         json={
@@ -359,11 +359,11 @@ async def test_api_add_non_auth_user(unbound_http_client: AsyncClient) -> None:
     data = response.json()
 
     assert response.status_code == 401
-    assert data.get('detail') == 'Could not validate credentials'
+    assert data.get("detail") == "Could not validate credentials"
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_api_add_with_incorrect_dn(http_client: AsyncClient) -> None:
     """Test API add a user with incorrect DN."""
     response = await http_client.post(
@@ -377,11 +377,11 @@ async def test_api_add_with_incorrect_dn(http_client: AsyncClient) -> None:
 
     data = response.json()
     assert isinstance(data, dict)
-    assert data.get('resultCode') == LDAPCodes.INVALID_DN_SYNTAX
+    assert data.get("resultCode") == LDAPCodes.INVALID_DN_SYNTAX
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_api_add_with_incorrect_name(http_client: AsyncClient) -> None:
     """Test API add a user with incorrect name."""
     response = await http_client.post(
@@ -394,11 +394,11 @@ async def test_api_add_with_incorrect_name(http_client: AsyncClient) -> None:
     )
 
     data = response.json()
-    assert data.get('resultCode') == LDAPCodes.INVALID_DN_SYNTAX
+    assert data.get("resultCode") == LDAPCodes.INVALID_DN_SYNTAX
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_api_add_with_space_end_name(http_client: AsyncClient) -> None:
     """Test API add a user with incorrect name."""
     entry = "cn=test test ,dc=md,dc=test"
@@ -417,7 +417,7 @@ async def test_api_add_with_space_end_name(http_client: AsyncClient) -> None:
     )
 
     data = response.json()
-    assert data.get('resultCode') == LDAPCodes.SUCCESS
+    assert data.get("resultCode") == LDAPCodes.SUCCESS
 
     response = await http_client.post(
         "entry/search",
@@ -435,11 +435,11 @@ async def test_api_add_with_space_end_name(http_client: AsyncClient) -> None:
     )
     data = response.json()
 
-    assert data['search_result'][0]['object_name'] == entry
+    assert data["search_result"][0]["object_name"] == entry
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_api_add_with_non_exist_parent(http_client: AsyncClient) -> None:
     """Test API add a user with non-existen parent."""
     response = await http_client.post(
@@ -454,13 +454,13 @@ async def test_api_add_with_non_exist_parent(http_client: AsyncClient) -> None:
     data = response.json()
 
     assert isinstance(data, dict)
-    assert data.get('resultCode') == LDAPCodes.NO_SUCH_OBJECT
+    assert data.get("resultCode") == LDAPCodes.NO_SUCH_OBJECT
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('adding_test_user')
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("adding_test_user")
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_api_double_add(http_client: AsyncClient) -> None:
     """Test API for adding a user who already exists."""
     response = await http_client.post(
@@ -494,11 +494,11 @@ async def test_api_double_add(http_client: AsyncClient) -> None:
     data = response.json()
 
     assert isinstance(data, dict)
-    assert data.get('resultCode') == LDAPCodes.ENTRY_ALREADY_EXISTS
+    assert data.get("resultCode") == LDAPCodes.ENTRY_ALREADY_EXISTS
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_api_add_double_case_insensetive(
         http_client: AsyncClient) -> None:
     """Test api double add."""
@@ -529,7 +529,7 @@ async def test_api_add_double_case_insensetive(
         },
     )
 
-    assert response.json().get('resultCode') == LDAPCodes.SUCCESS
+    assert response.json().get("resultCode") == LDAPCodes.SUCCESS
 
     response = await http_client.post(
         "/entry/add",
@@ -558,4 +558,4 @@ async def test_api_add_double_case_insensetive(
         },
     )
 
-    assert response.json().get('resultCode') == LDAPCodes.ENTRY_ALREADY_EXISTS
+    assert response.json().get("resultCode") == LDAPCodes.ENTRY_ALREADY_EXISTS

--- a/tests/test_api/test_main/test_router/test_add.py
+++ b/tests/test_api/test_main/test_router/test_add.py
@@ -3,6 +3,7 @@
 Copyright (c) 2024 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
+
 import pytest
 from fastapi import status
 from httpx import AsyncClient
@@ -100,8 +101,10 @@ async def test_api_add_computer(http_client: AsyncClient) -> None:
 
     for attr in data["search_result"][0]["partial_attributes"]:
         if attr["type"] == "userAccountControl":
-            assert int(attr["vals"][0]) &\
-                UserAccountControlFlag.WORKSTATION_TRUST_ACCOUNT
+            assert (
+                int(attr["vals"][0])
+                & UserAccountControlFlag.WORKSTATION_TRUST_ACCOUNT
+            )
             break
     else:
         raise Exception("Computer without userAccountControl")
@@ -110,7 +113,8 @@ async def test_api_add_computer(http_client: AsyncClient) -> None:
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("session")
 async def test_api_correct_add_double_member_of(
-        http_client: AsyncClient) -> None:
+    http_client: AsyncClient,
+) -> None:
     """Test api correct add a group with a register.
 
     assigning it to a user,
@@ -260,8 +264,7 @@ async def test_api_correct_add_double_member_of(
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("session")
-async def test_api_add_user_inccorect_uac(
-        http_client: AsyncClient) -> None:
+async def test_api_add_user_inccorect_uac(http_client: AsyncClient) -> None:
     """Test api add."""
     user = "cn=test0,dc=md,dc=test"
     un = "test0"
@@ -345,8 +348,7 @@ async def test_api_add_user_inccorect_uac(
 @pytest.mark.usefixtures("session")
 async def test_api_add_non_auth_user(unbound_http_client: AsyncClient) -> None:
     """Test API add for unauthorized user."""
-    unbound_http_client.cookies.set(
-        "id", "09e67421-2f92-8ddc-494108a6e04f")
+    unbound_http_client.cookies.set("id", "09e67421-2f92-8ddc-494108a6e04f")
     response = await unbound_http_client.post(
         "/entry/add",
         json={
@@ -500,7 +502,8 @@ async def test_api_double_add(http_client: AsyncClient) -> None:
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("session")
 async def test_api_add_double_case_insensetive(
-        http_client: AsyncClient) -> None:
+    http_client: AsyncClient,
+) -> None:
     """Test api double add."""
     response = await http_client.post(
         "/entry/add",

--- a/tests/test_api/test_main/test_router/test_delete.py
+++ b/tests/test_api/test_main/test_router/test_delete.py
@@ -3,6 +3,7 @@
 Copyright (c) 2024 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
+
 import pytest
 from httpx import AsyncClient
 
@@ -16,7 +17,8 @@ from ldap_protocol.ldap_codes import LDAPCodes
 async def test_api_correct_delete(http_client: AsyncClient) -> None:
     """Test API for delete object."""
     response = await http_client.request(
-        "delete", "/entry/delete",
+        "delete",
+        "/entry/delete",
         json={"entry": "cn=test,dc=md,dc=test"},
     )
 
@@ -50,8 +52,7 @@ async def test_api_delete_with_incorrect_dn(http_client: AsyncClient) -> None:
 @pytest.mark.usefixtures("adding_test_user")
 @pytest.mark.usefixtures("setup_session")
 @pytest.mark.usefixtures("session")
-async def test_api_delete_non_exist_object(
-        http_client: AsyncClient) -> None:
+async def test_api_delete_non_exist_object(http_client: AsyncClient) -> None:
     """Test API for delete non-existen object."""
     response = await http_client.request(
         "delete",

--- a/tests/test_api/test_main/test_router/test_delete.py
+++ b/tests/test_api/test_main/test_router/test_delete.py
@@ -10,9 +10,9 @@ from ldap_protocol.ldap_codes import LDAPCodes
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('adding_test_user')
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("adding_test_user")
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_api_correct_delete(http_client: AsyncClient) -> None:
     """Test API for delete object."""
     response = await http_client.request(
@@ -23,13 +23,13 @@ async def test_api_correct_delete(http_client: AsyncClient) -> None:
     data = response.json()
 
     assert isinstance(data, dict)
-    assert data.get('resultCode') == LDAPCodes.SUCCESS
+    assert data.get("resultCode") == LDAPCodes.SUCCESS
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('adding_test_user')
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("adding_test_user")
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_api_delete_with_incorrect_dn(http_client: AsyncClient) -> None:
     """Test API for delete object with incorrect DN."""
     response = await http_client.request(
@@ -43,13 +43,13 @@ async def test_api_delete_with_incorrect_dn(http_client: AsyncClient) -> None:
     data = response.json()
 
     assert isinstance(data, dict)
-    assert data.get('resultCode') == LDAPCodes.INVALID_DN_SYNTAX
+    assert data.get("resultCode") == LDAPCodes.INVALID_DN_SYNTAX
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('adding_test_user')
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("adding_test_user")
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_api_delete_non_exist_object(
         http_client: AsyncClient) -> None:
     """Test API for delete non-existen object."""
@@ -64,4 +64,4 @@ async def test_api_delete_non_exist_object(
     data = response.json()
 
     assert isinstance(data, dict)
-    assert data.get('resultCode') == LDAPCodes.NO_SUCH_OBJECT
+    assert data.get("resultCode") == LDAPCodes.NO_SUCH_OBJECT

--- a/tests/test_api/test_main/test_router/test_login.py
+++ b/tests/test_api/test_main/test_router/test_login.py
@@ -12,7 +12,7 @@ from tests.conftest import TestCreds
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_api_before_setup(
         unbound_http_client: httpx.AsyncClient) -> None:
     """Test api before setup."""
@@ -22,8 +22,8 @@ async def test_api_before_setup(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('adding_test_user')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("adding_test_user")
+@pytest.mark.usefixtures("session")
 async def test_api_auth_after_change_account_exp(
         http_client: httpx.AsyncClient) -> None:
     """Test api auth."""
@@ -45,8 +45,8 @@ async def test_api_auth_after_change_account_exp(
     auth = await http_client.post(
         "auth/",
         data={
-            "username": 'new_user@md.test',
-            "password": 'P@ssw0rd',
+            "username": "new_user@md.test",
+            "password": "P@ssw0rd",
         })
 
     assert auth.status_code == status.HTTP_403_FORBIDDEN
@@ -69,14 +69,14 @@ async def test_api_auth_after_change_account_exp(
     auth = await http_client.post(
         "auth/",
         data={
-            "username": 'new_user@md.test',
-            "password": 'P@ssw0rd',
+            "username": "new_user@md.test",
+            "password": "P@ssw0rd",
         })
 
-    assert auth.cookies.get('id')
+    assert auth.cookies.get("id")
 
 
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_refresh_and_logout_flow(
         unbound_http_client: httpx.AsyncClient,
         creds: TestCreds) -> None:
@@ -85,7 +85,7 @@ async def test_refresh_and_logout_flow(
         "auth/",
         data={"username": creds.un, "password": creds.pw})
 
-    old_token = unbound_http_client.cookies.get('id')
+    old_token = unbound_http_client.cookies.get("id")
 
     assert old_token
 

--- a/tests/test_api/test_main/test_router/test_login.py
+++ b/tests/test_api/test_main/test_router/test_login.py
@@ -3,6 +3,7 @@
 Copyright (c) 2024 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
+
 import httpx
 import pytest
 from fastapi import status
@@ -14,7 +15,8 @@ from tests.conftest import TestCreds
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("session")
 async def test_api_before_setup(
-        unbound_http_client: httpx.AsyncClient) -> None:
+    unbound_http_client: httpx.AsyncClient,
+) -> None:
     """Test api before setup."""
     response = await unbound_http_client.get("auth/me")
 
@@ -25,7 +27,8 @@ async def test_api_before_setup(
 @pytest.mark.usefixtures("adding_test_user")
 @pytest.mark.usefixtures("session")
 async def test_api_auth_after_change_account_exp(
-        http_client: httpx.AsyncClient) -> None:
+    http_client: httpx.AsyncClient,
+) -> None:
     """Test api auth."""
     await http_client.patch(
         "/entry/update",
@@ -47,7 +50,8 @@ async def test_api_auth_after_change_account_exp(
         data={
             "username": "new_user@md.test",
             "password": "P@ssw0rd",
-        })
+        },
+    )
 
     assert auth.status_code == status.HTTP_403_FORBIDDEN
 
@@ -71,19 +75,20 @@ async def test_api_auth_after_change_account_exp(
         data={
             "username": "new_user@md.test",
             "password": "P@ssw0rd",
-        })
+        },
+    )
 
     assert auth.cookies.get("id")
 
 
 @pytest.mark.usefixtures("setup_session")
 async def test_refresh_and_logout_flow(
-        unbound_http_client: httpx.AsyncClient,
-        creds: TestCreds) -> None:
+    unbound_http_client: httpx.AsyncClient, creds: TestCreds
+) -> None:
     """Test login, refresh and logout cookie flow."""
     await unbound_http_client.post(
-        "auth/",
-        data={"username": creds.un, "password": creds.pw})
+        "auth/", data={"username": creds.un, "password": creds.pw}
+    )
 
     old_token = unbound_http_client.cookies.get("id")
 

--- a/tests/test_api/test_main/test_router/test_modify.py
+++ b/tests/test_api/test_main/test_router/test_modify.py
@@ -11,12 +11,12 @@ from ldap_protocol.ldap_requests.modify import Operation
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('adding_test_user')
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("adding_test_user")
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_api_correct_modify(http_client: AsyncClient) -> None:
     """Test API for modify object attribute."""
-    entry_dn = 'cn=test,dc=md,dc=test'
+    entry_dn = "cn=test,dc=md,dc=test"
     new_value = "133632677730000000"
     response = await http_client.patch(
         "/entry/update",
@@ -37,7 +37,7 @@ async def test_api_correct_modify(http_client: AsyncClient) -> None:
     data = response.json()
 
     assert isinstance(data, dict)
-    assert data.get('resultCode') == LDAPCodes.SUCCESS
+    assert data.get("resultCode") == LDAPCodes.SUCCESS
 
     response = await http_client.post(
         "entry/search",
@@ -56,21 +56,21 @@ async def test_api_correct_modify(http_client: AsyncClient) -> None:
 
     data = response.json()
 
-    assert data['resultCode'] == LDAPCodes.SUCCESS
-    assert data['search_result'][0]['object_name'] == entry_dn
+    assert data["resultCode"] == LDAPCodes.SUCCESS
+    assert data["search_result"][0]["object_name"] == entry_dn
 
-    for attr in data['search_result'][0]['partial_attributes']:
-        if attr['type'] == 'accountExpires':
-            assert attr['vals'][0] == new_value
+    for attr in data["search_result"][0]["partial_attributes"]:
+        if attr["type"] == "accountExpires":
+            assert attr["vals"][0] == new_value
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('adding_test_user')
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("adding_test_user")
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_api_modify_many(http_client: AsyncClient) -> None:
     """Test API for modify object attribute."""
-    entry_dn = 'cn=test,dc=md,dc=test'
+    entry_dn = "cn=test,dc=md,dc=test"
     new_value = "133632677730000000"
     response = await http_client.patch(
         "/entry/update_many",
@@ -106,7 +106,7 @@ async def test_api_modify_many(http_client: AsyncClient) -> None:
 
     assert isinstance(data, list)
     for result in data:
-        assert result.get('resultCode') == LDAPCodes.SUCCESS
+        assert result.get("resultCode") == LDAPCodes.SUCCESS
 
     response = await http_client.post(
         "entry/search",
@@ -125,20 +125,20 @@ async def test_api_modify_many(http_client: AsyncClient) -> None:
 
     data = response.json()
 
-    assert data['resultCode'] == LDAPCodes.SUCCESS
-    assert data['search_result'][0]['object_name'] == entry_dn
+    assert data["resultCode"] == LDAPCodes.SUCCESS
+    assert data["search_result"][0]["object_name"] == entry_dn
 
-    for attr in data['search_result'][0]['partial_attributes']:
-        if attr['type'] == 'accountExpires':
-            assert attr['vals'][0] == new_value
-        if attr['type'] == 'testing_attr':
-            assert attr['vals'][0] == 'test1'
+    for attr in data["search_result"][0]["partial_attributes"]:
+        if attr["type"] == "accountExpires":
+            assert attr["vals"][0] == new_value
+        if attr["type"] == "testing_attr":
+            assert attr["vals"][0] == "test1"
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('adding_test_user')
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("adding_test_user")
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_api_modify_with_incorrect_dn(http_client: AsyncClient) -> None:
     """Test API for modify object attribute with incorrect DN."""
     response = await http_client.patch(
@@ -160,11 +160,11 @@ async def test_api_modify_with_incorrect_dn(http_client: AsyncClient) -> None:
     data = response.json()
 
     assert isinstance(data, dict)
-    assert data.get('resultCode') == LDAPCodes.INVALID_DN_SYNTAX
+    assert data.get("resultCode") == LDAPCodes.INVALID_DN_SYNTAX
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_api_modify_non_exist_object(http_client: AsyncClient) -> None:
     """Test API for modify object attribute with non-existen attribute."""
     response = await http_client.patch(
@@ -186,18 +186,18 @@ async def test_api_modify_non_exist_object(http_client: AsyncClient) -> None:
     data = response.json()
 
     assert isinstance(data, dict)
-    assert data.get('resultCode') == LDAPCodes.NO_SUCH_OBJECT
+    assert data.get("resultCode") == LDAPCodes.NO_SUCH_OBJECT
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('adding_test_user')
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("adding_test_user")
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_api_correct_modify_replace_memberof(
         http_client: AsyncClient) -> None:
     """Test API for modify object attribute."""
-    user = 'cn=user1,ou=moscow,ou=russia,ou=users,dc=md,dc=test'
-    new_group = 'cn=domain admins,cn=groups,dc=md,dc=test'
+    user = "cn=user1,ou=moscow,ou=russia,ou=users,dc=md,dc=test"
+    new_group = "cn=domain admins,cn=groups,dc=md,dc=test"
     response = await http_client.patch(
         "/entry/update",
         json={
@@ -215,7 +215,7 @@ async def test_api_correct_modify_replace_memberof(
     )
     data = response.json()
 
-    assert data['resultCode'] == LDAPCodes.SUCCESS
+    assert data["resultCode"] == LDAPCodes.SUCCESS
 
     response = await http_client.post(
         "entry/search",
@@ -234,33 +234,33 @@ async def test_api_correct_modify_replace_memberof(
 
     data = response.json()
 
-    assert user == data['search_result'][0]['object_name']
+    assert user == data["search_result"][0]["object_name"]
 
-    for attr in data['search_result'][0]['partial_attributes']:
-        if attr['type'] == 'memberOf':
-            assert attr['vals'] == [new_group]
+    for attr in data["search_result"][0]["partial_attributes"]:
+        if attr["type"] == "memberOf":
+            assert attr["vals"] == [new_group]
             break
     else:
-        raise Exception('No groups')
+        raise Exception("No groups")
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('adding_test_user')
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("adding_test_user")
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_api_modify_add_loop_detect_member(
         http_client: AsyncClient) -> None:
     """Test API for modify object attribute."""
     response = await http_client.patch(
         "/entry/update",
         json={
-            "object": 'cn=developers,cn=groups,dc=md,dc=test',
+            "object": "cn=developers,cn=groups,dc=md,dc=test",
             "changes": [
                 {
                     "operation": Operation.ADD,
                     "modification": {
                         "type": "member",
-                        "vals": ['cn=user0,ou=users,dc=md,dc=test'],
+                        "vals": ["cn=user0,ou=users,dc=md,dc=test"],
                     },
                 },
             ],
@@ -268,26 +268,26 @@ async def test_api_modify_add_loop_detect_member(
     )
     data = response.json()
 
-    assert data['resultCode'] == LDAPCodes.LOOP_DETECT
+    assert data["resultCode"] == LDAPCodes.LOOP_DETECT
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('adding_test_user')
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("adding_test_user")
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_api_modify_add_loop_detect_memberof(
         http_client: AsyncClient) -> None:
     """Test API for modify object attribute."""
     response = await http_client.patch(
         "/entry/update",
         json={
-            "object": 'cn=user0,ou=users,dc=md,dc=test',
+            "object": "cn=user0,ou=users,dc=md,dc=test",
             "changes": [
                 {
                     "operation": Operation.ADD,
                     "modification": {
                         "type": "memberOf",
-                        "vals": ['cn=developers,cn=groups,dc=md,dc=test'],
+                        "vals": ["cn=developers,cn=groups,dc=md,dc=test"],
                     },
                 },
             ],
@@ -295,27 +295,27 @@ async def test_api_modify_add_loop_detect_memberof(
     )
     data = response.json()
 
-    assert data['resultCode'] == LDAPCodes.LOOP_DETECT
+    assert data["resultCode"] == LDAPCodes.LOOP_DETECT
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('adding_test_user')
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("adding_test_user")
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_api_modify_replace_loop_detect_member(
         http_client: AsyncClient) -> None:
     """Test API for modify object attribute."""
     response = await http_client.patch(
         "/entry/update",
         json={
-            "object": 'cn=developers,cn=groups,dc=md,dc=test',
+            "object": "cn=developers,cn=groups,dc=md,dc=test",
             "changes": [
                 {
                     "operation": Operation.REPLACE,
                     "modification": {
                         "type": "member",
                         "vals": [
-                            'cn=user0,ou=users,dc=md,dc=test',
+                            "cn=user0,ou=users,dc=md,dc=test",
                             'cn=user1,ou=moscow,ou=russia,ou=users,dc=md,dc=test',  # noqa
                         ],
                     },
@@ -325,28 +325,28 @@ async def test_api_modify_replace_loop_detect_member(
     )
     data = response.json()
 
-    assert data['resultCode'] == LDAPCodes.LOOP_DETECT
+    assert data["resultCode"] == LDAPCodes.LOOP_DETECT
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('adding_test_user')
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("adding_test_user")
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_api_modify_replace_loop_detect_memberof(
         http_client: AsyncClient) -> None:
     """Test API for modify object attribute."""
     response = await http_client.patch(
         "/entry/update",
         json={
-            "object": 'cn=user0,ou=users,dc=md,dc=test',
+            "object": "cn=user0,ou=users,dc=md,dc=test",
             "changes": [
                 {
                     "operation": Operation.REPLACE,
                     "modification": {
                         "type": "memberOf",
                         "vals": [
-                            'cn=developers,cn=groups,dc=md,dc=test',
-                            'cn=domain admins,cn=groups,dc=md,dc=test',
+                            "cn=developers,cn=groups,dc=md,dc=test",
+                            "cn=domain admins,cn=groups,dc=md,dc=test",
                         ],
                     },
                 },
@@ -355,24 +355,24 @@ async def test_api_modify_replace_loop_detect_memberof(
     )
     data = response.json()
 
-    assert data['resultCode'] == LDAPCodes.LOOP_DETECT
+    assert data["resultCode"] == LDAPCodes.LOOP_DETECT
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('adding_test_user')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("adding_test_user")
+@pytest.mark.usefixtures("session")
 async def test_api_modify_incorrect_uac(http_client: AsyncClient) -> None:
     """Test API for modify object attribute."""
     response = await http_client.patch(
         "/entry/update",
         json={
-            "object": 'cn=user0,ou=users,dc=md,dc=test',
+            "object": "cn=user0,ou=users,dc=md,dc=test",
             "changes": [
                 {
                     "operation": Operation.REPLACE,
                     "modification": {
                         "type": "userAccountControl",
-                        "vals": ['string'],
+                        "vals": ["string"],
                     },
                 },
             ],
@@ -380,4 +380,4 @@ async def test_api_modify_incorrect_uac(http_client: AsyncClient) -> None:
     )
     data = response.json()
 
-    assert data['resultCode'] == LDAPCodes.UNDEFINED_ATTRIBUTE_TYPE
+    assert data["resultCode"] == LDAPCodes.UNDEFINED_ATTRIBUTE_TYPE

--- a/tests/test_api/test_main/test_router/test_modify.py
+++ b/tests/test_api/test_main/test_router/test_modify.py
@@ -3,6 +3,7 @@
 Copyright (c) 2024 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
+
 import pytest
 from httpx import AsyncClient
 
@@ -194,7 +195,8 @@ async def test_api_modify_non_exist_object(http_client: AsyncClient) -> None:
 @pytest.mark.usefixtures("setup_session")
 @pytest.mark.usefixtures("session")
 async def test_api_correct_modify_replace_memberof(
-        http_client: AsyncClient) -> None:
+    http_client: AsyncClient,
+) -> None:
     """Test API for modify object attribute."""
     user = "cn=user1,ou=moscow,ou=russia,ou=users,dc=md,dc=test"
     new_group = "cn=domain admins,cn=groups,dc=md,dc=test"
@@ -249,7 +251,8 @@ async def test_api_correct_modify_replace_memberof(
 @pytest.mark.usefixtures("setup_session")
 @pytest.mark.usefixtures("session")
 async def test_api_modify_add_loop_detect_member(
-        http_client: AsyncClient) -> None:
+    http_client: AsyncClient,
+) -> None:
     """Test API for modify object attribute."""
     response = await http_client.patch(
         "/entry/update",
@@ -276,7 +279,8 @@ async def test_api_modify_add_loop_detect_member(
 @pytest.mark.usefixtures("setup_session")
 @pytest.mark.usefixtures("session")
 async def test_api_modify_add_loop_detect_memberof(
-        http_client: AsyncClient) -> None:
+    http_client: AsyncClient,
+) -> None:
     """Test API for modify object attribute."""
     response = await http_client.patch(
         "/entry/update",
@@ -303,7 +307,8 @@ async def test_api_modify_add_loop_detect_memberof(
 @pytest.mark.usefixtures("setup_session")
 @pytest.mark.usefixtures("session")
 async def test_api_modify_replace_loop_detect_member(
-        http_client: AsyncClient) -> None:
+    http_client: AsyncClient,
+) -> None:
     """Test API for modify object attribute."""
     response = await http_client.patch(
         "/entry/update",
@@ -316,7 +321,7 @@ async def test_api_modify_replace_loop_detect_member(
                         "type": "member",
                         "vals": [
                             "cn=user0,ou=users,dc=md,dc=test",
-                            'cn=user1,ou=moscow,ou=russia,ou=users,dc=md,dc=test',  # noqa
+                            "cn=user1,ou=moscow,ou=russia,ou=users,dc=md,dc=test",
                         ],
                     },
                 },
@@ -333,7 +338,8 @@ async def test_api_modify_replace_loop_detect_member(
 @pytest.mark.usefixtures("setup_session")
 @pytest.mark.usefixtures("session")
 async def test_api_modify_replace_loop_detect_memberof(
-        http_client: AsyncClient) -> None:
+    http_client: AsyncClient,
+) -> None:
     """Test API for modify object attribute."""
     response = await http_client.patch(
         "/entry/update",

--- a/tests/test_api/test_main/test_router/test_modify_dn.py
+++ b/tests/test_api/test_main/test_router/test_modify_dn.py
@@ -10,20 +10,20 @@ from ldap_protocol.ldap_codes import LDAPCodes
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('adding_test_user')
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("adding_test_user")
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_api_correct_update_dn(http_client: AsyncClient) -> None:
     """Test API for update DN."""
     root_dn = "ou=moscow,ou=russia,ou=users,dc=md,dc=test"
 
     old_user_dn = "cn=user1," + root_dn
     newrdn_user = "cn=new_test2"
-    new_user_dn = ','.join((newrdn_user, root_dn))
+    new_user_dn = ",".join((newrdn_user, root_dn))
 
     old_group_dn = "cn=developers,cn=groups,dc=md,dc=test"
     new_group_dn = "cn=new_developers,cn=groups,dc=md,dc=test"
-    newrdn_group, new_superior_group = new_group_dn.split(',', maxsplit=1)
+    newrdn_group, new_superior_group = new_group_dn.split(",", maxsplit=1)
 
     response = await http_client.put(
         "/entry/update/dn",
@@ -38,7 +38,7 @@ async def test_api_correct_update_dn(http_client: AsyncClient) -> None:
     data = response.json()
 
     assert isinstance(data, dict)
-    assert data.get('resultCode') == LDAPCodes.SUCCESS
+    assert data.get("resultCode") == LDAPCodes.SUCCESS
 
     response = await http_client.post(
         "entry/search",
@@ -50,11 +50,11 @@ async def test_api_correct_update_dn(http_client: AsyncClient) -> None:
             "time_limit": 10,
             "types_only": False,
             "filter": "(objectClass=*)",
-            "attributes": ['*'],
+            "attributes": ["*"],
         },
     )
     data = response.json()
-    assert data['search_result'][0]['object_name'] == new_user_dn
+    assert data["search_result"][0]["object_name"] == new_user_dn
 
     response = await http_client.put(
         "/entry/update/dn",
@@ -69,7 +69,7 @@ async def test_api_correct_update_dn(http_client: AsyncClient) -> None:
     data = response.json()
 
     assert isinstance(data, dict)
-    assert data.get('resultCode') == LDAPCodes.SUCCESS
+    assert data.get("resultCode") == LDAPCodes.SUCCESS
 
     response = await http_client.post(
         "entry/search",
@@ -81,32 +81,32 @@ async def test_api_correct_update_dn(http_client: AsyncClient) -> None:
             "time_limit": 0,
             "types_only": False,
             "filter": "(objectClass=*)",
-            "attributes": ['memberOf'],
+            "attributes": ["memberOf"],
         },
     )
 
     data = response.json()
 
-    assert new_user_dn == data['search_result'][0]['object_name']
+    assert new_user_dn == data["search_result"][0]["object_name"]
 
-    for attr in data['search_result'][0]['partial_attributes']:
-        if attr['type'] == 'memberOf':
-            assert attr['vals'][0] == new_group_dn
+    for attr in data["search_result"][0]["partial_attributes"]:
+        if attr["type"] == "memberOf":
+            assert attr["vals"][0] == new_group_dn
             break
     else:
-        raise Exception('Groups not found')
+        raise Exception("Groups not found")
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('adding_test_user')
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("adding_test_user")
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_api_update_dn_with_parent(http_client: AsyncClient) -> None:
     """Test API for update DN."""
     old_user_dn = "cn=user1,ou=moscow,ou=russia,ou=users,dc=md,dc=test"
     new_user_dn = "cn=new_test2,ou=users,dc=md,dc=test"
     groups_user = None
-    newrdn_user, new_superior = new_user_dn.split(',', maxsplit=1)
+    newrdn_user, new_superior = new_user_dn.split(",", maxsplit=1)
 
     response = await http_client.post(
         "entry/search",
@@ -118,18 +118,18 @@ async def test_api_update_dn_with_parent(http_client: AsyncClient) -> None:
             "time_limit": 0,
             "types_only": False,
             "filter": "(objectClass=*)",
-            "attributes": ['*'],
+            "attributes": ["*"],
         },
     )
 
     data = response.json()
 
-    assert data.get('resultCode') == LDAPCodes.SUCCESS
-    assert old_user_dn == data['search_result'][0]['object_name']
+    assert data.get("resultCode") == LDAPCodes.SUCCESS
+    assert old_user_dn == data["search_result"][0]["object_name"]
 
-    for attr in data['search_result'][0]['partial_attributes']:
-        if attr['type'] == 'memberOf':
-            groups_user = attr['vals']
+    for attr in data["search_result"][0]["partial_attributes"]:
+        if attr["type"] == "memberOf":
+            groups_user = attr["vals"]
 
     assert groups_user
 
@@ -145,7 +145,7 @@ async def test_api_update_dn_with_parent(http_client: AsyncClient) -> None:
 
     data = response.json()
 
-    assert data.get('resultCode') == LDAPCodes.SUCCESS
+    assert data.get("resultCode") == LDAPCodes.SUCCESS
 
     response = await http_client.post(
         "entry/search",
@@ -157,26 +157,26 @@ async def test_api_update_dn_with_parent(http_client: AsyncClient) -> None:
             "time_limit": 0,
             "types_only": False,
             "filter": "(objectClass=*)",
-            "attributes": ['*'],
+            "attributes": ["*"],
         },
     )
 
     data = response.json()
 
-    assert data.get('resultCode') == LDAPCodes.SUCCESS
-    assert new_user_dn == data['search_result'][0]['object_name']
+    assert data.get("resultCode") == LDAPCodes.SUCCESS
+    assert new_user_dn == data["search_result"][0]["object_name"]
 
-    for attr in data['search_result'][0]['partial_attributes']:
-        if attr['type'] == 'memberOf':
-            assert groups_user == attr['vals']
+    for attr in data["search_result"][0]["partial_attributes"]:
+        if attr["type"] == "memberOf":
+            assert groups_user == attr["vals"]
             break
     else:
-        raise Exception('Groups not found')
+        raise Exception("Groups not found")
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_api_update_dn_non_auth_user(http_client: AsyncClient) -> None:
     """Test API update dn for unauthorized user."""
     http_client.cookies.clear()
@@ -192,13 +192,13 @@ async def test_api_update_dn_non_auth_user(http_client: AsyncClient) -> None:
 
     data = response.json()
     assert response.status_code == 401
-    assert data.get('detail') == 'Could not validate credentials'
+    assert data.get("detail") == "Could not validate credentials"
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('adding_test_user')
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("adding_test_user")
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_api_update_dn_non_exist_superior(
         http_client: AsyncClient) -> None:
     """Test API update dn with non-existen new_superior."""
@@ -215,13 +215,13 @@ async def test_api_update_dn_non_exist_superior(
     data = response.json()
 
     assert isinstance(data, dict)
-    assert data.get('resultCode') == LDAPCodes.NO_SUCH_OBJECT
+    assert data.get("resultCode") == LDAPCodes.NO_SUCH_OBJECT
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('adding_test_user')
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("adding_test_user")
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_api_update_dn_non_exist_entry(http_client: AsyncClient) -> None:
     """Test API update dn with non-existen entry."""
     response = await http_client.put(
@@ -237,13 +237,13 @@ async def test_api_update_dn_non_exist_entry(http_client: AsyncClient) -> None:
     data = response.json()
 
     assert isinstance(data, dict)
-    assert data.get('resultCode') == LDAPCodes.NO_SUCH_OBJECT
+    assert data.get("resultCode") == LDAPCodes.NO_SUCH_OBJECT
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('adding_test_user')
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("adding_test_user")
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_api_update_dn_invalid_entry(http_client: AsyncClient) -> None:
     """Test API update dn with invalid entry."""
     response = await http_client.put(
@@ -259,13 +259,13 @@ async def test_api_update_dn_invalid_entry(http_client: AsyncClient) -> None:
     data = response.json()
 
     assert isinstance(data, dict)
-    assert data.get('resultCode') == LDAPCodes.INVALID_DN_SYNTAX
+    assert data.get("resultCode") == LDAPCodes.INVALID_DN_SYNTAX
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('adding_test_user')
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("adding_test_user")
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_api_update_dn_invalid_new_superior(
         http_client: AsyncClient) -> None:
     """Test API update dn with invalid new_superior."""
@@ -282,4 +282,4 @@ async def test_api_update_dn_invalid_new_superior(
     data = response.json()
 
     assert isinstance(data, dict)
-    assert data.get('resultCode') == LDAPCodes.INVALID_DN_SYNTAX
+    assert data.get("resultCode") == LDAPCodes.INVALID_DN_SYNTAX

--- a/tests/test_api/test_main/test_router/test_modify_dn.py
+++ b/tests/test_api/test_main/test_router/test_modify_dn.py
@@ -3,6 +3,7 @@
 Copyright (c) 2024 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
+
 import pytest
 from httpx import AsyncClient
 
@@ -200,7 +201,8 @@ async def test_api_update_dn_non_auth_user(http_client: AsyncClient) -> None:
 @pytest.mark.usefixtures("setup_session")
 @pytest.mark.usefixtures("session")
 async def test_api_update_dn_non_exist_superior(
-        http_client: AsyncClient) -> None:
+    http_client: AsyncClient,
+) -> None:
     """Test API update dn with non-existen new_superior."""
     response = await http_client.put(
         "/entry/update/dn",
@@ -267,7 +269,8 @@ async def test_api_update_dn_invalid_entry(http_client: AsyncClient) -> None:
 @pytest.mark.usefixtures("setup_session")
 @pytest.mark.usefixtures("session")
 async def test_api_update_dn_invalid_new_superior(
-        http_client: AsyncClient) -> None:
+    http_client: AsyncClient,
+) -> None:
     """Test API update dn with invalid new_superior."""
     response = await http_client.put(
         "/entry/update/dn",

--- a/tests/test_api/test_main/test_router/test_search.py
+++ b/tests/test_api/test_main/test_router/test_search.py
@@ -3,6 +3,7 @@
 Copyright (c) 2024 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
+
 import uuid
 
 import pytest
@@ -40,23 +41,30 @@ async def test_api_root_dse(http_client: AsyncClient) -> None:
     aquired_attrs = [attr["type"] for attr in attrs]
 
     root_attrs = [
-        "LDAPServiceName", "currentTime",
-        "defaultNamingContext", "dnsHostName",
-        "domainFunctionality", "dsServiceName",
-        "highestCommittedUSN", "namingContexts",
-        "rootDomainNamingContext", "vendorVersion",
-        "schemaNamingContext", "serverName",
-        "serviceName", "subschemaSubentry",
-        "supportedCapabilities", "supportedControl",
-        "supportedLDAPPolicies", "supportedLDAPVersion",
-        "supportedSASLMechanisms", "vendorName",
+        "LDAPServiceName",
+        "currentTime",
+        "defaultNamingContext",
+        "dnsHostName",
+        "domainFunctionality",
+        "dsServiceName",
+        "highestCommittedUSN",
+        "namingContexts",
+        "rootDomainNamingContext",
+        "vendorVersion",
+        "schemaNamingContext",
+        "serverName",
+        "serviceName",
+        "subschemaSubentry",
+        "supportedCapabilities",
+        "supportedControl",
+        "supportedLDAPPolicies",
+        "supportedLDAPVersion",
+        "supportedSASLMechanisms",
+        "vendorName",
     ]
 
     assert data["search_result"][0]["object_name"] == ""
-    assert all(
-        attr in aquired_attrs
-        for attr in root_attrs
-    )
+    assert all(attr in aquired_attrs for attr in root_attrs)
 
 
 @pytest.mark.asyncio
@@ -87,8 +95,7 @@ async def test_api_search(http_client: AsyncClient) -> None:
         "ou=users,dc=md,dc=test",
     ]
     assert all(
-        obj["object_name"] in sub_dirs
-        for obj in response["search_result"]
+        obj["object_name"] in sub_dirs for obj in response["search_result"]
     )
 
 
@@ -193,8 +200,9 @@ async def test_api_search_filter_objectguid(http_client: AsyncClient) -> None:
     )
     data = raw_response.json()
 
-    assert data["search_result"][0]["object_name"] == entry_dn, \
+    assert data["search_result"][0]["object_name"] == entry_dn, (
         "User with required objectGUID not found"
+    )
 
 
 @pytest.mark.asyncio
@@ -261,10 +269,7 @@ async def test_api_search_recursive_memberof(http_client: AsyncClient) -> None:
     )
     data = response.json()
     assert len(data["search_result"]) == len(members)
-    assert all(
-        obj["object_name"] in members
-        for obj in data["search_result"]
-    )
+    assert all(obj["object_name"] in members for obj in data["search_result"])
 
 
 @pytest.mark.asyncio

--- a/tests/test_api/test_main/test_router/test_search.py
+++ b/tests/test_api/test_main/test_router/test_search.py
@@ -12,7 +12,7 @@ from ldap_protocol.ldap_codes import LDAPCodes
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_api_root_dse(http_client: AsyncClient) -> None:
     """Test api root dse."""
     response = await http_client.post(
@@ -33,26 +33,26 @@ async def test_api_root_dse(http_client: AsyncClient) -> None:
     data = response.json()
 
     attrs = sorted(
-        data['search_result'][0]['partial_attributes'],
-        key=lambda x: x['type'],
+        data["search_result"][0]["partial_attributes"],
+        key=lambda x: x["type"],
     )
 
-    aquired_attrs = [attr['type'] for attr in attrs]
+    aquired_attrs = [attr["type"] for attr in attrs]
 
     root_attrs = [
-        'LDAPServiceName', 'currentTime',
-        'defaultNamingContext', 'dnsHostName',
-        'domainFunctionality', 'dsServiceName',
-        'highestCommittedUSN', 'namingContexts',
-        'rootDomainNamingContext', 'vendorVersion',
-        'schemaNamingContext', 'serverName',
-        'serviceName', 'subschemaSubentry',
-        'supportedCapabilities', 'supportedControl',
-        'supportedLDAPPolicies', 'supportedLDAPVersion',
-        'supportedSASLMechanisms', 'vendorName',
+        "LDAPServiceName", "currentTime",
+        "defaultNamingContext", "dnsHostName",
+        "domainFunctionality", "dsServiceName",
+        "highestCommittedUSN", "namingContexts",
+        "rootDomainNamingContext", "vendorVersion",
+        "schemaNamingContext", "serverName",
+        "serviceName", "subschemaSubentry",
+        "supportedCapabilities", "supportedControl",
+        "supportedLDAPPolicies", "supportedLDAPVersion",
+        "supportedSASLMechanisms", "vendorName",
     ]
 
-    assert data['search_result'][0]['object_name'] == ""
+    assert data["search_result"][0]["object_name"] == ""
     assert all(
         attr in aquired_attrs
         for attr in root_attrs
@@ -60,7 +60,7 @@ async def test_api_root_dse(http_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_api_search(http_client: AsyncClient) -> None:
     """Test api search."""
     raw_response = await http_client.post(
@@ -80,23 +80,23 @@ async def test_api_search(http_client: AsyncClient) -> None:
 
     response = raw_response.json()
 
-    assert response['resultCode'] == LDAPCodes.SUCCESS
+    assert response["resultCode"] == LDAPCodes.SUCCESS
 
     sub_dirs = [
         "cn=groups,dc=md,dc=test",
         "ou=users,dc=md,dc=test",
     ]
     assert all(
-        obj['object_name'] in sub_dirs
-        for obj in response['search_result']
+        obj["object_name"] in sub_dirs
+        for obj in response["search_result"]
     )
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_api_search_filter_memberof(http_client: AsyncClient) -> None:
     """Test api search."""
-    member = 'cn=user1,ou=moscow,ou=russia,ou=users,dc=md,dc=test'
+    member = "cn=user1,ou=moscow,ou=russia,ou=users,dc=md,dc=test"
     raw_response = await http_client.post(
         "entry/search",
         json={
@@ -114,16 +114,16 @@ async def test_api_search_filter_memberof(http_client: AsyncClient) -> None:
 
     response = raw_response.json()
 
-    assert response['resultCode'] == LDAPCodes.SUCCESS
-    assert response['search_result'][0]['object_name'] == member
+    assert response["resultCode"] == LDAPCodes.SUCCESS
+    assert response["search_result"][0]["object_name"] == member
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_api_search_filter_member(http_client: AsyncClient) -> None:
     """Test api search."""
-    member = 'cn=user1,ou=moscow,ou=russia,ou=users,dc=md,dc=test'
-    group = 'cn=developers,cn=groups,dc=md,dc=test'
+    member = "cn=user1,ou=moscow,ou=russia,ou=users,dc=md,dc=test"
+    group = "cn=developers,cn=groups,dc=md,dc=test"
     raw_response = await http_client.post(
         "entry/search",
         json={
@@ -141,12 +141,12 @@ async def test_api_search_filter_member(http_client: AsyncClient) -> None:
 
     response = raw_response.json()
 
-    assert response['resultCode'] == LDAPCodes.SUCCESS
-    assert response['search_result'][0]['object_name'] == group
+    assert response["resultCode"] == LDAPCodes.SUCCESS
+    assert response["search_result"][0]["object_name"] == group
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_api_search_filter_objectguid(http_client: AsyncClient) -> None:
     """Test api search."""
     raw_response = await http_client.post(
@@ -166,14 +166,14 @@ async def test_api_search_filter_objectguid(http_client: AsyncClient) -> None:
     data = raw_response.json()
 
     hex_guid = None
-    entry_dn = data['search_result'][3]['object_name']
+    entry_dn = data["search_result"][3]["object_name"]
 
-    for attr in data['search_result'][3]['partial_attributes']:
-        if attr['type'] == 'objectGUID':
-            hex_guid = attr['vals'][0]
+    for attr in data["search_result"][3]["partial_attributes"]:
+        if attr["type"] == "objectGUID":
+            hex_guid = attr["vals"][0]
             break
 
-    assert hex_guid is not None, 'objectGUID attribute is missing'
+    assert hex_guid is not None, "objectGUID attribute is missing"
 
     object_guid = str(uuid.UUID(bytes_le=bytes(bytearray.fromhex(hex_guid))))
 
@@ -193,12 +193,12 @@ async def test_api_search_filter_objectguid(http_client: AsyncClient) -> None:
     )
     data = raw_response.json()
 
-    assert data['search_result'][0]['object_name'] == entry_dn, \
+    assert data["search_result"][0]["object_name"] == entry_dn, \
         "User with required objectGUID not found"
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_api_search_complex_filter(http_client: AsyncClient) -> None:
     """Test api search."""
     user = "cn=user1,ou=moscow,ou=russia,ou=users,dc=md,dc=test"
@@ -232,11 +232,11 @@ async def test_api_search_complex_filter(http_client: AsyncClient) -> None:
         },
     )
     data = raw_response.json()
-    assert data['search_result'][0]['object_name'] == user
+    assert data["search_result"][0]["object_name"] == user
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_api_search_recursive_memberof(http_client: AsyncClient) -> None:
     """Test api search."""
     group = "cn=domain admins,cn=groups,dc=md,dc=test"
@@ -260,15 +260,15 @@ async def test_api_search_recursive_memberof(http_client: AsyncClient) -> None:
         },
     )
     data = response.json()
-    assert len(data['search_result']) == len(members)
+    assert len(data["search_result"]) == len(members)
     assert all(
-        obj['object_name'] in members
-        for obj in data['search_result']
+        obj["object_name"] in members
+        for obj in data["search_result"]
     )
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_api_bytes_to_hex(http_client: AsyncClient) -> None:
     """Test api search."""
     raw_response = await http_client.post(
@@ -288,8 +288,8 @@ async def test_api_bytes_to_hex(http_client: AsyncClient) -> None:
 
     response = raw_response.json()
 
-    assert response['resultCode'] == LDAPCodes.SUCCESS
+    assert response["resultCode"] == LDAPCodes.SUCCESS
 
-    for attr in response['search_result'][0]['partial_attributes']:
-        if attr['type'] == 'attr_with_bvalue':
-            assert attr['vals'][0] == b"any".hex()
+    for attr in response["search_result"][0]["partial_attributes"]:
+        if attr["type"] == "attr_with_bvalue":
+            assert attr["vals"][0] == b"any".hex()

--- a/tests/test_api/test_network/test_router.py
+++ b/tests/test_api/test_network/test_router.py
@@ -17,21 +17,42 @@ from models import NetworkPolicy
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("session")
-async def test_add_policy(
-        http_client: AsyncClient) -> None:
+async def test_add_policy(http_client: AsyncClient) -> None:
     """Test api policy add and read."""
     compare_netmasks = [
-        "127.0.0.1/32", "172.0.0.2/31", "172.0.0.4/30",
-        "172.0.0.8/29", "172.0.0.16/28", "172.0.0.32/27",
-        "172.0.0.64/26", "172.0.0.128/25", "172.0.1.0/24",
-        "172.0.2.0/23", "172.0.4.0/22", "172.0.8.0/21",
-        "172.0.16.0/20", "172.0.32.0/19", "172.0.64.0/18",
-        "172.0.128.0/17", "172.1.0.0/16", "172.2.0.0/15",
-        "172.4.0.0/14", "172.8.0.0/13", "172.16.0.0/12",
-        "172.32.0.0/11", "172.64.0.0/10", "172.128.0.0/10",
-        "172.192.0.0/11", "172.224.0.0/12", "172.240.0.0/13",
-        "172.248.0.0/14", "172.252.0.0/15", "172.254.0.0/16",
-        "172.255.0.0/24", "172.255.1.0/30", "172.255.1.4/31",
+        "127.0.0.1/32",
+        "172.0.0.2/31",
+        "172.0.0.4/30",
+        "172.0.0.8/29",
+        "172.0.0.16/28",
+        "172.0.0.32/27",
+        "172.0.0.64/26",
+        "172.0.0.128/25",
+        "172.0.1.0/24",
+        "172.0.2.0/23",
+        "172.0.4.0/22",
+        "172.0.8.0/21",
+        "172.0.16.0/20",
+        "172.0.32.0/19",
+        "172.0.64.0/18",
+        "172.0.128.0/17",
+        "172.1.0.0/16",
+        "172.2.0.0/15",
+        "172.4.0.0/14",
+        "172.8.0.0/13",
+        "172.16.0.0/12",
+        "172.32.0.0/11",
+        "172.64.0.0/10",
+        "172.128.0.0/10",
+        "172.192.0.0/11",
+        "172.224.0.0/12",
+        "172.240.0.0/13",
+        "172.248.0.0/14",
+        "172.252.0.0/15",
+        "172.254.0.0/16",
+        "172.255.0.0/24",
+        "172.255.1.0/30",
+        "172.255.1.4/31",
         "172.8.4.0/24",
     ]
 
@@ -41,17 +62,20 @@ async def test_add_policy(
         "172.8.4.0/24",
     ]
 
-    raw_response = await http_client.post("/policy", json={
-        "name": "local seriveses",
-        "netmasks": raw_netmasks,
-        "priority": 2,
-        "groups": ["cn=domain admins,cn=groups,dc=md,dc=test"],
-        "is_http": True,
-        "is_ldap": True,
-        "is_kerberos": True,
-        "bypass_no_connection": False,
-        "bypass_service_failure": False,
-    })
+    raw_response = await http_client.post(
+        "/policy",
+        json={
+            "name": "local seriveses",
+            "netmasks": raw_netmasks,
+            "priority": 2,
+            "groups": ["cn=domain admins,cn=groups,dc=md,dc=test"],
+            "is_http": True,
+            "is_ldap": True,
+            "is_kerberos": True,
+            "bypass_no_connection": False,
+            "bypass_service_failure": False,
+        },
+    )
 
     assert raw_response.status_code == 201
     assert raw_response.json()["netmasks"] == compare_netmasks
@@ -131,7 +155,8 @@ async def test_update_policy(http_client: AsyncClient) -> None:
             "id": pol_id,
             "groups": ["cn=domain admins,cn=groups,dc=md,dc=test"],
             "name": "Default open policy 2",
-        })
+        },
+    )
 
     assert response.status_code == status.HTTP_200_OK
 
@@ -185,13 +210,15 @@ async def test_delete_policy(
     session: AsyncSession,
 ) -> None:
     """Delete policy."""
-    session.add(NetworkPolicy(
-        name="Local policy",
-        netmasks=[IPv4Network("127.100.10.5/32")],
-        raw=["127.100.10.5/32"],
-        enabled=True,
-        priority=2,
-    ))
+    session.add(
+        NetworkPolicy(
+            name="Local policy",
+            netmasks=[IPv4Network("127.100.10.5/32")],
+            raw=["127.100.10.5/32"],
+            enabled=True,
+            priority=2,
+        )
+    )
     await session.commit()
 
     raw_response = await http_client.get("/policy")
@@ -218,7 +245,8 @@ async def test_delete_policy(
     }
 
     response = await http_client.delete(
-        f"/policy/{pol_id}", follow_redirects=False)
+        f"/policy/{pol_id}", follow_redirects=False
+    )
     assert response.status_code == 303
     assert response.next_request.url.path == "/api/policy"
     response = await http_client.get("/policy")
@@ -240,13 +268,15 @@ async def test_switch_policy(
     session: AsyncSession,
 ) -> None:
     """Switch policy."""
-    session.add(NetworkPolicy(
-        name="Local policy",
-        netmasks=[IPv4Network("127.100.10.5/32")],
-        raw=["127.100.10.5/32"],
-        enabled=True,
-        priority=2,
-    ))
+    session.add(
+        NetworkPolicy(
+            name="Local policy",
+            netmasks=[IPv4Network("127.100.10.5/32")],
+            raw=["127.100.10.5/32"],
+            enabled=True,
+            priority=2,
+        )
+    )
     await session.commit()
 
     raw_response = await http_client.get("/policy")
@@ -367,6 +397,7 @@ async def test_swap(http_client: AsyncClient) -> None:
 
     assert response[0]["priority"] == 1
     assert response[0]["groups"] == [
-        "cn=domain admins,cn=groups,dc=md,dc=test"]
+        "cn=domain admins,cn=groups,dc=md,dc=test"
+    ]
     assert response[1]["priority"] == 2
     assert response[1]["name"] == "Default open policy"

--- a/tests/test_api/test_network/test_router.py
+++ b/tests/test_api/test_network/test_router.py
@@ -16,23 +16,23 @@ from models import NetworkPolicy
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_add_policy(
         http_client: AsyncClient) -> None:
     """Test api policy add and read."""
     compare_netmasks = [
-        '127.0.0.1/32', '172.0.0.2/31', '172.0.0.4/30',
-        '172.0.0.8/29', '172.0.0.16/28', '172.0.0.32/27',
-        '172.0.0.64/26', '172.0.0.128/25', '172.0.1.0/24',
-        '172.0.2.0/23', '172.0.4.0/22', '172.0.8.0/21',
-        '172.0.16.0/20', '172.0.32.0/19', '172.0.64.0/18',
-        '172.0.128.0/17', '172.1.0.0/16', '172.2.0.0/15',
-        '172.4.0.0/14', '172.8.0.0/13', '172.16.0.0/12',
-        '172.32.0.0/11', '172.64.0.0/10', '172.128.0.0/10',
-        '172.192.0.0/11', '172.224.0.0/12', '172.240.0.0/13',
-        '172.248.0.0/14', '172.252.0.0/15', '172.254.0.0/16',
-        '172.255.0.0/24', '172.255.1.0/30', '172.255.1.4/31',
-        '172.8.4.0/24',
+        "127.0.0.1/32", "172.0.0.2/31", "172.0.0.4/30",
+        "172.0.0.8/29", "172.0.0.16/28", "172.0.0.32/27",
+        "172.0.0.64/26", "172.0.0.128/25", "172.0.1.0/24",
+        "172.0.2.0/23", "172.0.4.0/22", "172.0.8.0/21",
+        "172.0.16.0/20", "172.0.32.0/19", "172.0.64.0/18",
+        "172.0.128.0/17", "172.1.0.0/16", "172.2.0.0/15",
+        "172.4.0.0/14", "172.8.0.0/13", "172.16.0.0/12",
+        "172.32.0.0/11", "172.64.0.0/10", "172.128.0.0/10",
+        "172.192.0.0/11", "172.224.0.0/12", "172.240.0.0/13",
+        "172.248.0.0/14", "172.252.0.0/15", "172.254.0.0/16",
+        "172.255.0.0/24", "172.255.1.0/30", "172.255.1.4/31",
+        "172.8.4.0/24",
     ]
 
     raw_netmasks = [
@@ -45,12 +45,12 @@ async def test_add_policy(
         "name": "local seriveses",
         "netmasks": raw_netmasks,
         "priority": 2,
-        'groups': ['cn=domain admins,cn=groups,dc=md,dc=test'],
-        'is_http': True,
-        'is_ldap': True,
-        'is_kerberos': True,
-        'bypass_no_connection': False,
-        'bypass_service_failure': False,
+        "groups": ["cn=domain admins,cn=groups,dc=md,dc=test"],
+        "is_http": True,
+        "is_ldap": True,
+        "is_kerberos": True,
+        "bypass_no_connection": False,
+        "bypass_service_failure": False,
     })
 
     assert raw_response.status_code == 201
@@ -61,120 +61,120 @@ async def test_add_policy(
     response = raw_response.json()
 
     for pol in response:
-        pol.pop('id')
+        pol.pop("id")
 
     assert response == [
         {
-            'enabled': True,
-            'name': 'Default open policy',
-            'netmasks': ['0.0.0.0/0'],
-            'raw': ['0.0.0.0/0'],
-            'groups': [],
-            'priority': 1,
-            'mfa_groups': [],
-            'mfa_status': 0,
-            'is_http': True,
-            'is_ldap': True,
-            'is_kerberos': True,
-            'bypass_no_connection': False,
-            'bypass_service_failure': False,
+            "enabled": True,
+            "name": "Default open policy",
+            "netmasks": ["0.0.0.0/0"],
+            "raw": ["0.0.0.0/0"],
+            "groups": [],
+            "priority": 1,
+            "mfa_groups": [],
+            "mfa_status": 0,
+            "is_http": True,
+            "is_ldap": True,
+            "is_kerberos": True,
+            "bypass_no_connection": False,
+            "bypass_service_failure": False,
         },
         {
-            'enabled': True,
-            'name': 'local seriveses',
-            'netmasks': compare_netmasks,
-            'raw': raw_netmasks,
-            'groups': ['cn=domain admins,cn=groups,dc=md,dc=test'],
-            'priority': 2,
-            'mfa_groups': [],
-            'mfa_status': 0,
-            'is_http': True,
-            'is_ldap': True,
-            'is_kerberos': True,
-            'bypass_no_connection': False,
-            'bypass_service_failure': False,
+            "enabled": True,
+            "name": "local seriveses",
+            "netmasks": compare_netmasks,
+            "raw": raw_netmasks,
+            "groups": ["cn=domain admins,cn=groups,dc=md,dc=test"],
+            "priority": 2,
+            "mfa_groups": [],
+            "mfa_status": 0,
+            "is_http": True,
+            "is_ldap": True,
+            "is_kerberos": True,
+            "bypass_no_connection": False,
+            "bypass_service_failure": False,
         },
     ]
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_update_policy(http_client: AsyncClient) -> None:
     """Update policy."""
     raw_response = await http_client.get("/policy")
     assert raw_response.status_code == status.HTTP_200_OK
     response = raw_response.json()
 
-    pol_id = response[0].pop('id')
+    pol_id = response[0].pop("id")
 
     assert response == [
         {
-            'enabled': True,
-            'name': 'Default open policy',
-            'netmasks': ['0.0.0.0/0'],
-            'raw': ['0.0.0.0/0'],
-            'priority': 1,
-            'mfa_groups': [],
-            'mfa_status': 0,
-            'groups': [],
-            'is_http': True,
-            'is_ldap': True,
-            'is_kerberos': True,
-            'bypass_no_connection': False,
-            'bypass_service_failure': False,
+            "enabled": True,
+            "name": "Default open policy",
+            "netmasks": ["0.0.0.0/0"],
+            "raw": ["0.0.0.0/0"],
+            "priority": 1,
+            "mfa_groups": [],
+            "mfa_status": 0,
+            "groups": [],
+            "is_http": True,
+            "is_ldap": True,
+            "is_kerberos": True,
+            "bypass_no_connection": False,
+            "bypass_service_failure": False,
         },
     ]
 
     response = await http_client.put(
         "/policy",
         json={
-            'id': pol_id,
-            'groups': ['cn=domain admins,cn=groups,dc=md,dc=test'],
-            'name': 'Default open policy 2',
+            "id": pol_id,
+            "groups": ["cn=domain admins,cn=groups,dc=md,dc=test"],
+            "name": "Default open policy 2",
         })
 
     assert response.status_code == status.HTTP_200_OK
 
     response = response.json()
-    response.pop('id')
+    response.pop("id")
 
     assert response == {
-        'enabled': True,
-        'name': 'Default open policy 2',
-        'netmasks': ['0.0.0.0/0'],
-        'raw': ['0.0.0.0/0'],
-        'groups': ['cn=domain admins,cn=groups,dc=md,dc=test'],
-        'mfa_groups': [],
-        'mfa_status': 0,
-        'priority': 1,
-        'is_http': True,
-        'is_ldap': True,
-        'is_kerberos': True,
-        'bypass_no_connection': False,
-        'bypass_service_failure': False,
+        "enabled": True,
+        "name": "Default open policy 2",
+        "netmasks": ["0.0.0.0/0"],
+        "raw": ["0.0.0.0/0"],
+        "groups": ["cn=domain admins,cn=groups,dc=md,dc=test"],
+        "mfa_groups": [],
+        "mfa_status": 0,
+        "priority": 1,
+        "is_http": True,
+        "is_ldap": True,
+        "is_kerberos": True,
+        "bypass_no_connection": False,
+        "bypass_service_failure": False,
     }
 
     response = await http_client.get("/policy")
     assert response.status_code == status.HTTP_200_OK
     response = response.json()
 
-    response[0].pop('id')
+    response[0].pop("id")
 
     assert response == [
         {
-            'enabled': True,
-            'name': 'Default open policy 2',
-            'netmasks': ['0.0.0.0/0'],
-            'raw': ['0.0.0.0/0'],
-            'mfa_groups': [],
-            'mfa_status': 0,
-            'priority': 1,
-            'groups': ['cn=domain admins,cn=groups,dc=md,dc=test'],
-            'is_http': True,
-            'is_ldap': True,
-            'is_kerberos': True,
-            'bypass_no_connection': False,
-            'bypass_service_failure': False,
+            "enabled": True,
+            "name": "Default open policy 2",
+            "netmasks": ["0.0.0.0/0"],
+            "raw": ["0.0.0.0/0"],
+            "mfa_groups": [],
+            "mfa_status": 0,
+            "priority": 1,
+            "groups": ["cn=domain admins,cn=groups,dc=md,dc=test"],
+            "is_http": True,
+            "is_ldap": True,
+            "is_kerberos": True,
+            "bypass_no_connection": False,
+            "bypass_service_failure": False,
         },
     ]
 
@@ -186,9 +186,9 @@ async def test_delete_policy(
 ) -> None:
     """Delete policy."""
     session.add(NetworkPolicy(
-        name='Local policy',
-        netmasks=[IPv4Network('127.100.10.5/32')],
-        raw=['127.100.10.5/32'],
+        name="Local policy",
+        netmasks=[IPv4Network("127.100.10.5/32")],
+        raw=["127.100.10.5/32"],
         enabled=True,
         priority=2,
     ))
@@ -198,40 +198,40 @@ async def test_delete_policy(
     assert raw_response.status_code == status.HTTP_200_OK
     response = raw_response.json()
 
-    pol_id = response[0].pop('id')
-    pol_id2 = response[1].pop('id')
+    pol_id = response[0].pop("id")
+    pol_id2 = response[1].pop("id")
 
     assert response[0] == {
-        'enabled': True,
-        'name': 'Default open policy',
-        'netmasks': ['0.0.0.0/0'],
-        'raw': ['0.0.0.0/0'],
-        'groups': [],
-        'mfa_groups': [],
-        'mfa_status': 0,
-        'priority': 1,
-        'is_http': True,
-        'is_ldap': True,
-        'is_kerberos': True,
-        'bypass_no_connection': False,
-        'bypass_service_failure': False,
+        "enabled": True,
+        "name": "Default open policy",
+        "netmasks": ["0.0.0.0/0"],
+        "raw": ["0.0.0.0/0"],
+        "groups": [],
+        "mfa_groups": [],
+        "mfa_status": 0,
+        "priority": 1,
+        "is_http": True,
+        "is_ldap": True,
+        "is_kerberos": True,
+        "bypass_no_connection": False,
+        "bypass_service_failure": False,
     }
 
     response = await http_client.delete(
         f"/policy/{pol_id}", follow_redirects=False)
     assert response.status_code == 303
-    assert response.next_request.url.path == '/api/policy'
+    assert response.next_request.url.path == "/api/policy"
     response = await http_client.get("/policy")
     assert response.status_code == status.HTTP_200_OK
     response = response.json()
 
     assert len(response) == 1
-    assert response[0]['name'] == "Local policy"
-    assert response[0]['priority'] == 1
+    assert response[0]["name"] == "Local policy"
+    assert response[0]["priority"] == 1
 
     response = await http_client.delete(f"/policy/{pol_id2}")
     assert response.status_code == 422
-    assert response.json()['detail'] == "At least one policy should be active"
+    assert response.json()["detail"] == "At least one policy should be active"
 
 
 @pytest.mark.asyncio
@@ -241,9 +241,9 @@ async def test_switch_policy(
 ) -> None:
     """Switch policy."""
     session.add(NetworkPolicy(
-        name='Local policy',
-        netmasks=[IPv4Network('127.100.10.5/32')],
-        raw=['127.100.10.5/32'],
+        name="Local policy",
+        netmasks=[IPv4Network("127.100.10.5/32")],
+        raw=["127.100.10.5/32"],
         enabled=True,
         priority=2,
     ))
@@ -253,23 +253,23 @@ async def test_switch_policy(
     assert raw_response.status_code == status.HTTP_200_OK
     response = raw_response.json()
 
-    pol_id = response[0].pop('id')
-    pol_id2 = response[1].pop('id')
+    pol_id = response[0].pop("id")
+    pol_id2 = response[1].pop("id")
 
     assert response[0] == {
-        'enabled': True,
-        'name': 'Default open policy',
-        'netmasks': ['0.0.0.0/0'],
-        'raw': ['0.0.0.0/0'],
-        'groups': [],
-        'mfa_groups': [],
-        'mfa_status': 0,
-        'priority': 1,
-        'is_http': True,
-        'is_ldap': True,
-        'is_kerberos': True,
-        'bypass_no_connection': False,
-        'bypass_service_failure': False,
+        "enabled": True,
+        "name": "Default open policy",
+        "netmasks": ["0.0.0.0/0"],
+        "raw": ["0.0.0.0/0"],
+        "groups": [],
+        "mfa_groups": [],
+        "mfa_status": 0,
+        "priority": 1,
+        "is_http": True,
+        "is_ldap": True,
+        "is_kerberos": True,
+        "bypass_no_connection": False,
+        "bypass_service_failure": False,
     }
 
     response = await http_client.patch(
@@ -279,20 +279,20 @@ async def test_switch_policy(
     assert response.json() is True
 
     response = await http_client.get("/policy")
-    assert response.json()[0]['enabled'] is False
+    assert response.json()[0]["enabled"] is False
 
     response = await http_client.patch(f"/policy/{pol_id2}")
     assert response.status_code == 422
-    assert response.json()['detail'] == "At least one policy should be active"
+    assert response.json()["detail"] == "At least one policy should be active"
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_404(http_client: AsyncClient) -> None:
     """Delete policy."""
     response = await http_client.get("/policy")
     assert response.status_code == status.HTTP_200_OK
-    some_id = response.json()[0]['id'] + 1
+    some_id = response.json()[0]["id"] + 1
 
     response = await http_client.delete(
         f"/policy/{some_id}",
@@ -307,15 +307,15 @@ async def test_404(http_client: AsyncClient) -> None:
     response = await http_client.put(
         "/policy",
         json={
-            'id': some_id,
-            "name": '123',
+            "id": some_id,
+            "name": "123",
         },
     )
     assert response.status_code == 404
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("session")
 async def test_swap(http_client: AsyncClient) -> None:
     """Test swap policies."""
     raw_response = await http_client.post(
@@ -331,42 +331,42 @@ async def test_swap(http_client: AsyncClient) -> None:
                 "172.8.4.0/24",
             ],
             "priority": 2,
-            'groups': ['cn=domain admins,cn=groups,dc=md,dc=test'],
-            'is_http': True,
-            'is_ldap': True,
-            'is_kerberos': True,
-            'bypass_no_connection': False,
-            'bypass_service_failure': False,
+            "groups": ["cn=domain admins,cn=groups,dc=md,dc=test"],
+            "is_http": True,
+            "is_ldap": True,
+            "is_kerberos": True,
+            "bypass_no_connection": False,
+            "bypass_service_failure": False,
         },
     )
 
     raw_get_response = await http_client.get("/policy")
     get_response = raw_get_response.json()
 
-    assert get_response[0]['priority'] == 1
-    assert get_response[0]['name'] == "Default open policy"
-    assert get_response[1]['priority'] == 2
+    assert get_response[0]["priority"] == 1
+    assert get_response[0]["name"] == "Default open policy"
+    assert get_response[1]["priority"] == 2
 
     swap_response = await http_client.post(
         "/policy/swap",
         json={
-            'first_policy_id': get_response[0]['id'],
-            'second_policy_id': get_response[1]['id'],
+            "first_policy_id": get_response[0]["id"],
+            "second_policy_id": get_response[1]["id"],
         },
     )
 
     assert swap_response.json() == {
-        "first_policy_id": get_response[0]['id'],
+        "first_policy_id": get_response[0]["id"],
         "first_policy_priority": 2,
-        "second_policy_id": get_response[1]['id'],
+        "second_policy_id": get_response[1]["id"],
         "second_policy_priority": 1,
     }
 
     raw_response = await http_client.get("/policy")
     response = raw_response.json()
 
-    assert response[0]['priority'] == 1
-    assert response[0]['groups'] == [
-        'cn=domain admins,cn=groups,dc=md,dc=test']
-    assert response[1]['priority'] == 2
-    assert response[1]['name'] == "Default open policy"
+    assert response[0]["priority"] == 1
+    assert response[0]["groups"] == [
+        "cn=domain admins,cn=groups,dc=md,dc=test"]
+    assert response[1]["priority"] == 2
+    assert response[1]["name"] == "Default open policy"

--- a/tests/test_api/test_shadow/conftest.py
+++ b/tests/test_api/test_shadow/conftest.py
@@ -30,13 +30,13 @@ class ProxyRequestModel(BaseModel):
 async def adding_mfa_keys(session: AsyncSession) -> None:
     """Test add user like keycloak."""
     session.add(
-        CatalogueSetting(name='mfa_secret', value='123'),
+        CatalogueSetting(name="mfa_secret", value="123"),
     )
-    session.add(CatalogueSetting(name='mfa_key', value='123'))
+    session.add(CatalogueSetting(name="mfa_key", value="123"))
     session.add(
-        CatalogueSetting(name='mfa_key_ldap', value='123'),
+        CatalogueSetting(name="mfa_key_ldap", value="123"),
     )
-    session.add(CatalogueSetting(name='mfa_secret_ldap', value='123'))
+    session.add(CatalogueSetting(name="mfa_secret_ldap", value="123"))
     await session.commit()
 
 

--- a/tests/test_api/test_shadow/conftest.py
+++ b/tests/test_api/test_shadow/conftest.py
@@ -20,6 +20,7 @@ class ProxyRequestModel(BaseModel):
     Attributes:
         principal: Unique user identifier
         ip: IP address from which the request is made
+
     """
 
     principal: str

--- a/tests/test_api/test_shadow/test_router.py
+++ b/tests/test_api/test_shadow/test_router.py
@@ -16,14 +16,14 @@ from .conftest import ProxyRequestModel
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_shadow_api_non_existent_user(http_client: AsyncClient) -> None:
     """Test shadow api with non-existent user."""
     response = await http_client.post(
         "/shadow/mfa/push",
         json=ProxyRequestModel(
-            principal='non-existent_user',
-            ip='127.0.0.1',
+            principal="non-existent_user",
+            ip="127.0.0.1",
         ).model_dump(),
     )
 
@@ -31,7 +31,7 @@ async def test_shadow_api_non_existent_user(http_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_shadow_api_without_network_policies(
     http_client: AsyncClient,
     adding_mfa_user_and_group: dict,
@@ -49,7 +49,7 @@ async def test_shadow_api_without_network_policies(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_shadow_api_without_kerberos_protocol(
     http_client: AsyncClient,
     adding_mfa_user_and_group: dict,
@@ -70,7 +70,7 @@ async def test_shadow_api_without_kerberos_protocol(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_shadow_api_with_disable_mfa(
     http_client: AsyncClient,
     adding_mfa_user_and_group: dict,
@@ -85,7 +85,7 @@ async def test_shadow_api_with_disable_mfa(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_shadow_api_whitelist_without_user_group(
     http_client: AsyncClient,
     adding_mfa_user_and_group: dict,
@@ -106,7 +106,7 @@ async def test_shadow_api_whitelist_without_user_group(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_shadow_api_enable_mfa(
     http_client: AsyncClient,
     adding_mfa_user_and_group: dict,

--- a/tests/test_api/test_shadow/test_router.py
+++ b/tests/test_api/test_shadow/test_router.py
@@ -57,8 +57,7 @@ async def test_shadow_api_without_kerberos_protocol(
 ) -> None:
     """Test shadow api without network policy with kerberos protocol."""
     await session.execute(
-        update(NetworkPolicy)
-        .values({NetworkPolicy.is_kerberos: False}),
+        update(NetworkPolicy).values({NetworkPolicy.is_kerberos: False}),
     )
 
     response = await http_client.post(
@@ -93,8 +92,9 @@ async def test_shadow_api_whitelist_without_user_group(
 ) -> None:
     """Test shadow api whitelist without user group."""
     await session.execute(
-        update(NetworkPolicy)
-        .values({NetworkPolicy.mfa_status: MFAFlags.WHITELIST}),
+        update(NetworkPolicy).values(
+            {NetworkPolicy.mfa_status: MFAFlags.WHITELIST}
+        ),
     )
 
     response = await http_client.post(
@@ -114,8 +114,9 @@ async def test_shadow_api_enable_mfa(
 ) -> None:
     """Test shadow api enable mfa."""
     await session.execute(
-        update(NetworkPolicy)
-        .values({NetworkPolicy.mfa_status: MFAFlags.ENABLED}),
+        update(NetworkPolicy).values(
+            {NetworkPolicy.mfa_status: MFAFlags.ENABLED}
+        ),
     )
 
     response = await http_client.post(

--- a/tests/test_ldap/test_bind.py
+++ b/tests/test_ldap/test_bind.py
@@ -51,8 +51,11 @@ async def test_bind_ok_and_unbind(
 
     result = await anext(
         bind.handle(
-            session, ldap_session,
-            kadmin, settings, None,  # type: ignore
+            session,
+            ldap_session,
+            kadmin,
+            settings,
+            None,  # type: ignore
         ),
     )
     assert result == BindResponse(result_code=LDAPCodes.SUCCESS)
@@ -309,7 +312,9 @@ async def test_anonymous_unbind(ldap_session: LDAPSession) -> None:
 @pytest.mark.usefixtures("setup_session")
 @pytest.mark.usefixtures("session")
 async def test_ldap3_bind(
-    ldap_client: Connection, event_loop: BaseEventLoop, creds: TestCreds,
+    ldap_client: Connection,
+    event_loop: BaseEventLoop,
+    creds: TestCreds,
 ) -> None:
     """Test ldap3 bind."""
     assert not ldap_client.bound
@@ -319,7 +324,8 @@ async def test_ldap3_bind(
     assert ldap_client.bound
 
     result = await event_loop.run_in_executor(
-        None, partial(ldap_client.rebind, user=creds.un, password=creds.pw),
+        None,
+        partial(ldap_client.rebind, user=creds.un, password=creds.pw),
     )
     assert result
     assert ldap_client.bound
@@ -332,7 +338,9 @@ async def test_ldap3_bind(
 @pytest.mark.usefixtures("setup_session")
 @pytest.mark.usefixtures("session")
 async def test_ldap3_bind_sasl_plain(
-    ldap_client: Connection, event_loop: BaseEventLoop, creds: TestCreds,
+    ldap_client: Connection,
+    event_loop: BaseEventLoop,
+    creds: TestCreds,
 ) -> None:
     """Test ldap3 bind."""
     assert not ldap_client.bound

--- a/tests/test_ldap/test_bind.py
+++ b/tests/test_ldap/test_bind.py
@@ -285,7 +285,7 @@ async def test_anonymous_bind(
     bind = BindRequest(
         version=0,
         name="",
-        AuthenticationChoice=SimpleAuthentication(password=""),  # noqa
+        AuthenticationChoice=SimpleAuthentication(password=""),
     )
     async with container(scope=Scope.REQUEST) as container:
         handler = await resolve_deps(bind.handle, container)

--- a/tests/test_ldap/test_ldap3_lib.py
+++ b/tests/test_ldap/test_ldap3_lib.py
@@ -14,8 +14,8 @@ from tests.conftest import TestCreds
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_ldap3_search(
         ldap_client: Connection,
         event_loop: BaseEventLoop,
@@ -27,7 +27,7 @@ async def test_ldap3_search(
     result = await event_loop.run_in_executor(
         None,
         partial(
-            ldap_client.search, 'dc=md,dc=test', '(objectclass=*)',
+            ldap_client.search, "dc=md,dc=test", "(objectclass=*)",
         ))
 
     assert result
@@ -35,22 +35,22 @@ async def test_ldap3_search(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_ldap3_search_memberof(
         ldap_client: Connection,
         event_loop: BaseEventLoop,
         creds: TestCreds) -> None:
     """Test ldap3 search memberof."""
-    member = 'cn=user1,ou=moscow,ou=russia,ou=users,dc=md,dc=test'
+    member = "cn=user1,ou=moscow,ou=russia,ou=users,dc=md,dc=test"
     await event_loop.run_in_executor(
         None, partial(ldap_client.rebind, user=creds.un, password=creds.pw))
 
     result = await event_loop.run_in_executor(
         None,
         partial(
-            ldap_client.search, 'dc=md,dc=test',
-            '(memberOf=cn=developers,cn=groups,dc=md,dc=test)',
+            ldap_client.search, "dc=md,dc=test",
+            "(memberOf=cn=developers,cn=groups,dc=md,dc=test)",
         ))
 
     assert result

--- a/tests/test_ldap/test_ldap3_lib.py
+++ b/tests/test_ldap/test_ldap3_lib.py
@@ -17,18 +17,21 @@ from tests.conftest import TestCreds
 @pytest.mark.usefixtures("setup_session")
 @pytest.mark.usefixtures("session")
 async def test_ldap3_search(
-        ldap_client: Connection,
-        event_loop: BaseEventLoop,
-        creds: TestCreds) -> None:
+    ldap_client: Connection, event_loop: BaseEventLoop, creds: TestCreds
+) -> None:
     """Test ldap3 search."""
     await event_loop.run_in_executor(
-        None, partial(ldap_client.rebind, user=creds.un, password=creds.pw))
+        None, partial(ldap_client.rebind, user=creds.un, password=creds.pw)
+    )
 
     result = await event_loop.run_in_executor(
         None,
         partial(
-            ldap_client.search, "dc=md,dc=test", "(objectclass=*)",
-        ))
+            ldap_client.search,
+            "dc=md,dc=test",
+            "(objectclass=*)",
+        ),
+    )
 
     assert result
     assert ldap_client.entries
@@ -38,20 +41,22 @@ async def test_ldap3_search(
 @pytest.mark.usefixtures("setup_session")
 @pytest.mark.usefixtures("session")
 async def test_ldap3_search_memberof(
-        ldap_client: Connection,
-        event_loop: BaseEventLoop,
-        creds: TestCreds) -> None:
+    ldap_client: Connection, event_loop: BaseEventLoop, creds: TestCreds
+) -> None:
     """Test ldap3 search memberof."""
     member = "cn=user1,ou=moscow,ou=russia,ou=users,dc=md,dc=test"
     await event_loop.run_in_executor(
-        None, partial(ldap_client.rebind, user=creds.un, password=creds.pw))
+        None, partial(ldap_client.rebind, user=creds.un, password=creds.pw)
+    )
 
     result = await event_loop.run_in_executor(
         None,
         partial(
-            ldap_client.search, "dc=md,dc=test",
+            ldap_client.search,
+            "dc=md,dc=test",
             "(memberOf=cn=developers,cn=groups,dc=md,dc=test)",
-        ))
+        ),
+    )
 
     assert result
     assert ldap_client.entries

--- a/tests/test_ldap/test_ldap3_whoami.py
+++ b/tests/test_ldap/test_ldap3_whoami.py
@@ -14,7 +14,7 @@ from tests.conftest import TestCreds
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_anonymous_whoami(
     event_loop: asyncio.BaseEventLoop,
     ldap_client: Connection,
@@ -30,7 +30,7 @@ async def test_anonymous_whoami(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_bind_whoami(
     event_loop: asyncio.BaseEventLoop,
     ldap_client: Connection,
@@ -43,4 +43,4 @@ async def test_bind_whoami(
     result = await event_loop.run_in_executor(
         None, ldap_client.extend.standard.who_am_i)
 
-    assert result == 'u:user0'
+    assert result == "u:user0"

--- a/tests/test_ldap/test_ldap3_whoami.py
+++ b/tests/test_ldap/test_ldap3_whoami.py
@@ -20,11 +20,11 @@ async def test_anonymous_whoami(
     ldap_client: Connection,
 ) -> None:
     """Test anonymous pwd change."""
-    await event_loop.run_in_executor(
-        None, partial(ldap_client.rebind))
+    await event_loop.run_in_executor(None, partial(ldap_client.rebind))
 
     result = await event_loop.run_in_executor(
-        None, ldap_client.extend.standard.who_am_i)
+        None, ldap_client.extend.standard.who_am_i
+    )
 
     assert result is None
 
@@ -38,9 +38,11 @@ async def test_bind_whoami(
 ) -> None:
     """Test anonymous pwd change."""
     await event_loop.run_in_executor(
-        None, partial(ldap_client.rebind, user=creds.un, password=creds.pw))
+        None, partial(ldap_client.rebind, user=creds.un, password=creds.pw)
+    )
 
     result = await event_loop.run_in_executor(
-        None, ldap_client.extend.standard.who_am_i)
+        None, ldap_client.extend.standard.who_am_i
+    )
 
     assert result == "u:user0"

--- a/tests/test_ldap/test_passwd_change.py
+++ b/tests/test_ldap/test_passwd_change.py
@@ -28,7 +28,7 @@ async def test_anonymous_pwd_change(
     """Test anonymous pwd change."""
     user_dn = "cn=user0,ou=users,dc=md,dc=test"
     password = creds.pw
-    new_test_password = 'Password123'  # noqa
+    new_test_password = "Password123"  # noqa
     await event_loop.run_in_executor(None, ldap_client.bind)
 
     result = await event_loop.run_in_executor(
@@ -38,7 +38,8 @@ async def test_anonymous_pwd_change(
             user_dn,
             old_password=password,
             new_password=new_test_password,
-        ))
+        ),
+    )
 
     assert result
 
@@ -63,9 +64,10 @@ async def test_bind_pwd_change(
     """Test anonymous pwd change."""
     user_dn = "cn=user0,ou=users,dc=md,dc=test"
     password = creds.pw
-    new_test_password = 'Password123'  # noqa
+    new_test_password = "Password123"  # noqa
     await event_loop.run_in_executor(
-        None, partial(ldap_client.rebind, user=user_dn, password=password))
+        None, partial(ldap_client.rebind, user=user_dn, password=password)
+    )
 
     result = await event_loop.run_in_executor(
         None,
@@ -73,7 +75,8 @@ async def test_bind_pwd_change(
             ldap_client.extend.standard.modify_password,
             old_password=password,
             new_password=new_test_password,
-        ))
+        ),
+    )
 
     assert result
 

--- a/tests/test_ldap/test_passwd_change.py
+++ b/tests/test_ldap/test_passwd_change.py
@@ -17,8 +17,8 @@ from tests.conftest import TestCreds
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('_force_override_tls')
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("_force_override_tls")
 async def test_anonymous_pwd_change(
     session: AsyncSession,
     event_loop: asyncio.BaseEventLoop,
@@ -33,7 +33,7 @@ async def test_anonymous_pwd_change(
 
     result = await event_loop.run_in_executor(
         None,
-        partial(  # noqa: S106
+        partial(
             ldap_client.extend.standard.modify_password,
             user_dn,
             old_password=password,
@@ -52,8 +52,8 @@ async def test_anonymous_pwd_change(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('_force_override_tls')
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("_force_override_tls")
 async def test_bind_pwd_change(
     session: AsyncSession,
     event_loop: asyncio.BaseEventLoop,
@@ -69,7 +69,7 @@ async def test_bind_pwd_change(
 
     result = await event_loop.run_in_executor(
         None,
-        partial(  # noqa: S106
+        partial(
             ldap_client.extend.standard.modify_password,
             old_password=password,
             new_password=new_test_password,

--- a/tests/test_ldap/test_pool_client_handler.py
+++ b/tests/test_ldap/test_pool_client_handler.py
@@ -15,8 +15,8 @@ from models import NetworkPolicy
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_check_policy(
         ldap_session: LDAPSession, session: AsyncSession) -> None:
     """Check policy."""
@@ -30,9 +30,9 @@ async def test_specific_policy_ok(
         ldap_session: LDAPSession, session: AsyncSession) -> None:
     """Test specific ip."""
     session.add(NetworkPolicy(
-        name='Local policy',
-        netmasks=[IPv4Network('127.100.10.5/32')],
-        raw=['127.100.10.5/32'],
+        name="Local policy",
+        netmasks=[IPv4Network("127.100.10.5/32")],
+        raw=["127.100.10.5/32"],
         enabled=True,
         priority=1,
     ))
@@ -46,8 +46,8 @@ async def test_specific_policy_ok(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('settings')
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("settings")
 async def test_check_policy_group(
         ldap_session: LDAPSession,
         session: AsyncSession) -> None:
@@ -55,13 +55,13 @@ async def test_check_policy_group(
     user = await get_user(session, "user0")
     assert user
 
-    policy = await ldap_session._get_policy(IPv4Address('127.0.0.1'), session)
+    policy = await ldap_session._get_policy(IPv4Address("127.0.0.1"), session)
     assert policy
 
     assert await is_user_group_valid(user, policy, session)
 
     group_dir = await get_group(
-        'cn=domain admins,cn=groups,dc=md,dc=test', session)
+        "cn=domain admins,cn=groups,dc=md,dc=test", session)
 
     policy.groups.append(group_dir.group)
     await session.commit()

--- a/tests/test_ldap/test_pool_client_handler.py
+++ b/tests/test_ldap/test_pool_client_handler.py
@@ -3,6 +3,7 @@
 Copyright (c) 2024 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
+
 from ipaddress import IPv4Address, IPv4Network
 
 import pytest
@@ -18,7 +19,8 @@ from models import NetworkPolicy
 @pytest.mark.usefixtures("setup_session")
 @pytest.mark.usefixtures("session")
 async def test_check_policy(
-        ldap_session: LDAPSession, session: AsyncSession) -> None:
+    ldap_session: LDAPSession, session: AsyncSession
+) -> None:
     """Check policy."""
     policy = await ldap_session._get_policy(IPv4Address("127.0.0.1"), session)
     assert policy
@@ -27,30 +29,35 @@ async def test_check_policy(
 
 @pytest.mark.asyncio
 async def test_specific_policy_ok(
-        ldap_session: LDAPSession, session: AsyncSession) -> None:
+    ldap_session: LDAPSession, session: AsyncSession
+) -> None:
     """Test specific ip."""
-    session.add(NetworkPolicy(
-        name="Local policy",
-        netmasks=[IPv4Network("127.100.10.5/32")],
-        raw=["127.100.10.5/32"],
-        enabled=True,
-        priority=1,
-    ))
+    session.add(
+        NetworkPolicy(
+            name="Local policy",
+            netmasks=[IPv4Network("127.100.10.5/32")],
+            raw=["127.100.10.5/32"],
+            enabled=True,
+            priority=1,
+        )
+    )
     await session.commit()
     policy = await ldap_session._get_policy(
-        IPv4Address("127.100.10.5"), session)
+        IPv4Address("127.100.10.5"), session
+    )
     assert policy
     assert policy.netmasks == [IPv4Network("127.100.10.5/32")]
     assert not await ldap_session._get_policy(
-        IPv4Address("127.100.10.4"), session)
+        IPv4Address("127.100.10.4"), session
+    )
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("setup_session")
 @pytest.mark.usefixtures("settings")
 async def test_check_policy_group(
-        ldap_session: LDAPSession,
-        session: AsyncSession) -> None:
+    ldap_session: LDAPSession, session: AsyncSession
+) -> None:
     """Check policy."""
     user = await get_user(session, "user0")
     assert user
@@ -61,7 +68,8 @@ async def test_check_policy_group(
     assert await is_user_group_valid(user, policy, session)
 
     group_dir = await get_group(
-        "cn=domain admins,cn=groups,dc=md,dc=test", session)
+        "cn=domain admins,cn=groups,dc=md,dc=test", session
+    )
 
     policy.groups.append(group_dir.group)
     await session.commit()

--- a/tests/test_ldap/test_util/test_add.py
+++ b/tests/test_ldap/test_util/test_add.py
@@ -25,11 +25,11 @@ from tests.conftest import TestCreds
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_ldap_root_add(
         session: AsyncSession, settings: Settings, user: dict) -> None:
     """Test ldapadd on server."""
-    dn = 'cn=test,dc=md,dc=test'
+    dn = "cn=test,dc=md,dc=test"
     search_path = get_search_path(dn)
     with tempfile.NamedTemporaryFile("w") as file:
         file.write((
@@ -42,10 +42,10 @@ async def test_ldap_root_add(
         ))
         file.seek(0)
         proc = await asyncio.create_subprocess_exec(
-            'ldapadd',
-            '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-            '-D', user['sam_accout_name'], '-x', '-w', user['password'],
-            '-f', file.name,
+            "ldapadd",
+            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
+            "-f", file.name,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE)
 
@@ -66,17 +66,17 @@ async def test_ldap_root_add(
     for attr in new_dir.attributes:
         attributes[attr.name].append(attr.value)
 
-    assert attributes['objectClass'] == ['organization', 'top']
+    assert attributes["objectClass"] == ["organization", "top"]
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_ldap_user_add_with_group(
         session: AsyncSession, settings: Settings, user: dict) -> None:
     """Test ldapadd on server."""
-    user_dn = 'cn=test,dc=md,dc=test'
+    user_dn = "cn=test,dc=md,dc=test"
     user_search_path = get_search_path(user_dn)
-    group_dn = 'cn=domain admins,cn=groups,dc=md,dc=test'
+    group_dn = "cn=domain admins,cn=groups,dc=md,dc=test"
 
     with tempfile.NamedTemporaryFile("w") as file:
         file.write(
@@ -94,10 +94,10 @@ async def test_ldap_user_add_with_group(
         )
         file.seek(0)
         proc = await asyncio.create_subprocess_exec(
-            'ldapadd',
-            '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-            '-D', user['sam_accout_name'], '-x', '-w', user['password'],
-            '-f', file.name,
+            "ldapadd",
+            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
+            "-f", file.name,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE)
 
@@ -121,13 +121,13 @@ async def test_ldap_user_add_with_group(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_ldap_user_add_group_with_group(
         session: AsyncSession, settings: Settings, user: dict) -> None:
     """Test ldapadd on server."""
-    child_group_dn = 'cn=twisted,cn=groups,dc=md,dc=test'
+    child_group_dn = "cn=twisted,cn=groups,dc=md,dc=test"
     child_group_search_path = get_search_path(child_group_dn)
-    group_dn = 'cn=domain admins,cn=groups,dc=md,dc=test'
+    group_dn = "cn=domain admins,cn=groups,dc=md,dc=test"
 
     with tempfile.NamedTemporaryFile("w") as file:
         file.write((
@@ -140,10 +140,10 @@ async def test_ldap_user_add_group_with_group(
         ))
         file.seek(0)
         proc = await asyncio.create_subprocess_exec(
-            'ldapadd',
-            '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-            '-D', user['sam_accout_name'], '-x', '-w', user['password'],
-            '-f', file.name,
+            "ldapadd",
+            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
+            "-f", file.name,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE)
 
@@ -167,8 +167,8 @@ async def test_ldap_user_add_group_with_group(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_add_bvalue_attr(
     session: AsyncSession,
     ldap_bound_session: LDAPSession,
@@ -185,11 +185,11 @@ async def test_add_bvalue_attr(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_ldap_add_access_control(
         session: AsyncSession, settings: Settings, creds: TestCreds) -> None:
     """Test ldapadd on server."""
-    dn = 'cn=test,dc=md,dc=test'
+    dn = "cn=test,dc=md,dc=test"
 
     async def try_add() -> int:
         with tempfile.NamedTemporaryFile("w") as file:
@@ -202,10 +202,10 @@ async def test_ldap_add_access_control(
             ))
             file.seek(0)
             proc = await asyncio.create_subprocess_exec(
-                'ldapadd',
-                '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-                '-D', "user_non_admin", '-x', '-w', creds.pw,
-                '-f', file.name,
+                "ldapadd",
+                "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+                "-D", "user_non_admin", "-x", "-w", creds.pw,
+                "-f", file.name,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE)
 
@@ -214,7 +214,7 @@ async def test_ldap_add_access_control(
     assert await try_add() == LDAPCodes.INSUFFICIENT_ACCESS_RIGHTS
 
     await create_access_policy(
-        name='DOMAIN Read Access Policy',
+        name="DOMAIN Read Access Policy",
         can_add=False,
         can_modify=False,
         can_read=True,
@@ -227,7 +227,7 @@ async def test_ldap_add_access_control(
     assert await try_add() == LDAPCodes.INSUFFICIENT_ACCESS_RIGHTS
 
     await create_access_policy(
-        name='DOMAIN Add Access Policy',
+        name="DOMAIN Add Access Policy",
         can_add=True,
         can_modify=False,
         can_read=True,
@@ -240,19 +240,19 @@ async def test_ldap_add_access_control(
     assert await try_add() == LDAPCodes.SUCCESS
 
     proc = await asyncio.create_subprocess_exec(
-        'ldapsearch',
-        '-vvv', '-x', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-        '-D', 'user_non_admin',
-        '-w', creds.pw,
-        '-b', 'dc=md,dc=test', 'objectclass=*',
+        "ldapsearch",
+        "-vvv", "-x", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D", "user_non_admin",
+        "-w", creds.pw,
+        "-b", "dc=md,dc=test", "objectclass=*",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE)
 
     raw_data, _ = await proc.communicate()
-    data = raw_data.decode().split('\n')
+    data = raw_data.decode().split("\n")
     result = await proc.wait()
 
-    dn_list = [d.removeprefix("dn: ") for d in data if d.startswith('dn:')]
+    dn_list = [d.removeprefix("dn: ") for d in data if d.startswith("dn:")]
 
     assert result == 0
     assert dn in dn_list

--- a/tests/test_ldap/test_util/test_add.py
+++ b/tests/test_ldap/test_util/test_add.py
@@ -27,37 +27,51 @@ from tests.conftest import TestCreds
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("setup_session")
 async def test_ldap_root_add(
-        session: AsyncSession, settings: Settings, user: dict) -> None:
+    session: AsyncSession, settings: Settings, user: dict
+) -> None:
     """Test ldapadd on server."""
     dn = "cn=test,dc=md,dc=test"
     search_path = get_search_path(dn)
     with tempfile.NamedTemporaryFile("w") as file:
-        file.write((
-            f"dn: {dn}\n"
-            "name: test\n"
-            "cn: test\n"
-            "objectClass: organization\n"
-            "objectClass: top\n"
-            "memberOf: cn=domain admins,cn=groups,dc=md,dc=test\n"
-        ))
+        file.write(
+            (
+                f"dn: {dn}\n"
+                "name: test\n"
+                "cn: test\n"
+                "objectClass: organization\n"
+                "objectClass: top\n"
+                "memberOf: cn=domain admins,cn=groups,dc=md,dc=test\n"
+            )
+        )
         file.seek(0)
         proc = await asyncio.create_subprocess_exec(
             "ldapadd",
-            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
-            "-f", file.name,
+            "-vvv",
+            "-H",
+            f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D",
+            user["sam_accout_name"],
+            "-x",
+            "-w",
+            user["password"],
+            "-f",
+            file.name,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
+            stderr=asyncio.subprocess.PIPE,
+        )
 
         # print(await proc.communicate())
         result = await proc.wait()
 
     assert result == 0
 
-    new_dir = (await session.scalars(
-        select(Directory)
-        .options(subqueryload(Directory.attributes))
-        .filter(Directory.path == search_path))).one()
+    new_dir = (
+        await session.scalars(
+            select(Directory)
+            .options(subqueryload(Directory.attributes))
+            .filter(Directory.path == search_path)
+        )
+    ).one()
 
     assert new_dir.name == "test"
 
@@ -72,7 +86,8 @@ async def test_ldap_root_add(
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("setup_session")
 async def test_ldap_user_add_with_group(
-        session: AsyncSession, settings: Settings, user: dict) -> None:
+    session: AsyncSession, settings: Settings, user: dict
+) -> None:
     """Test ldapadd on server."""
     user_dn = "cn=test,dc=md,dc=test"
     user_search_path = get_search_path(user_dn)
@@ -95,23 +110,37 @@ async def test_ldap_user_add_with_group(
         file.seek(0)
         proc = await asyncio.create_subprocess_exec(
             "ldapadd",
-            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
-            "-f", file.name,
+            "-vvv",
+            "-H",
+            f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D",
+            user["sam_accout_name"],
+            "-x",
+            "-w",
+            user["password"],
+            "-f",
+            file.name,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
+            stderr=asyncio.subprocess.PIPE,
+        )
 
         result = await proc.wait()
 
     assert result == 0
 
-    membership = selectinload(Directory.user).selectinload(
-        User.groups).selectinload(Group.directory)
+    membership = (
+        selectinload(Directory.user)
+        .selectinload(User.groups)
+        .selectinload(Group.directory)
+    )
 
-    new_dir = (await session.scalars(
-        select(Directory)
-        .options(subqueryload(Directory.attributes), membership)
-        .filter(Directory.path == user_search_path))).one()
+    new_dir = (
+        await session.scalars(
+            select(Directory)
+            .options(subqueryload(Directory.attributes), membership)
+            .filter(Directory.path == user_search_path)
+        )
+    ).one()
 
     assert new_dir.name == "test"
 
@@ -123,41 +152,58 @@ async def test_ldap_user_add_with_group(
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("setup_session")
 async def test_ldap_user_add_group_with_group(
-        session: AsyncSession, settings: Settings, user: dict) -> None:
+    session: AsyncSession, settings: Settings, user: dict
+) -> None:
     """Test ldapadd on server."""
     child_group_dn = "cn=twisted,cn=groups,dc=md,dc=test"
     child_group_search_path = get_search_path(child_group_dn)
     group_dn = "cn=domain admins,cn=groups,dc=md,dc=test"
 
     with tempfile.NamedTemporaryFile("w") as file:
-        file.write((
-            f"dn: {child_group_dn}\n"
-            "name: twisted\n"
-            "cn: twisted\n"
-            "objectClass: group\n"
-            "objectClass: top\n"
-            f"memberOf: {group_dn}\n"
-        ))
+        file.write(
+            (
+                f"dn: {child_group_dn}\n"
+                "name: twisted\n"
+                "cn: twisted\n"
+                "objectClass: group\n"
+                "objectClass: top\n"
+                f"memberOf: {group_dn}\n"
+            )
+        )
         file.seek(0)
         proc = await asyncio.create_subprocess_exec(
             "ldapadd",
-            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
-            "-f", file.name,
+            "-vvv",
+            "-H",
+            f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D",
+            user["sam_accout_name"],
+            "-x",
+            "-w",
+            user["password"],
+            "-f",
+            file.name,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
+            stderr=asyncio.subprocess.PIPE,
+        )
 
         result = await proc.wait()
 
         assert result == 0
 
-    membership = selectinload(Directory.group).selectinload(
-        Group.parent_groups).selectinload(Group.directory)
+    membership = (
+        selectinload(Directory.group)
+        .selectinload(Group.parent_groups)
+        .selectinload(Group.directory)
+    )
 
-    new_dir = (await session.scalars(
-        select(Directory)
-        .options(membership)
-        .filter(Directory.path == child_group_search_path))).one()
+    new_dir = (
+        await session.scalars(
+            select(Directory)
+            .options(membership)
+            .filter(Directory.path == child_group_search_path)
+        )
+    ).one()
 
     assert new_dir.name == "twisted"
 
@@ -187,27 +233,38 @@ async def test_add_bvalue_attr(
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("setup_session")
 async def test_ldap_add_access_control(
-        session: AsyncSession, settings: Settings, creds: TestCreds) -> None:
+    session: AsyncSession, settings: Settings, creds: TestCreds
+) -> None:
     """Test ldapadd on server."""
     dn = "cn=test,dc=md,dc=test"
 
     async def try_add() -> int:
         with tempfile.NamedTemporaryFile("w") as file:
-            file.write((
-                f"dn: {dn}\n"
-                "name: test\n"
-                "cn: test\n"
-                "objectClass: organization\n"
-                "objectClass: top\n"
-            ))
+            file.write(
+                (
+                    f"dn: {dn}\n"
+                    "name: test\n"
+                    "cn: test\n"
+                    "objectClass: organization\n"
+                    "objectClass: top\n"
+                )
+            )
             file.seek(0)
             proc = await asyncio.create_subprocess_exec(
                 "ldapadd",
-                "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-                "-D", "user_non_admin", "-x", "-w", creds.pw,
-                "-f", file.name,
+                "-vvv",
+                "-H",
+                f"ldap://{settings.HOST}:{settings.PORT}",
+                "-D",
+                "user_non_admin",
+                "-x",
+                "-w",
+                creds.pw,
+                "-f",
+                file.name,
                 stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE)
+                stderr=asyncio.subprocess.PIPE,
+            )
 
             return await proc.wait()
 
@@ -241,12 +298,20 @@ async def test_ldap_add_access_control(
 
     proc = await asyncio.create_subprocess_exec(
         "ldapsearch",
-        "-vvv", "-x", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-        "-D", "user_non_admin",
-        "-w", creds.pw,
-        "-b", "dc=md,dc=test", "objectclass=*",
+        "-vvv",
+        "-x",
+        "-H",
+        f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D",
+        "user_non_admin",
+        "-w",
+        creds.pw,
+        "-b",
+        "dc=md,dc=test",
+        "objectclass=*",
         stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE)
+        stderr=asyncio.subprocess.PIPE,
+    )
 
     raw_data, _ = await proc.communicate()
     data = raw_data.decode().split("\n")

--- a/tests/test_ldap/test_util/test_delete.py
+++ b/tests/test_ldap/test_util/test_delete.py
@@ -21,27 +21,38 @@ from tests.conftest import TestCreds
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("setup_session")
 async def test_ldap_delete(
-        session: AsyncSession, settings: Settings, user: dict) -> None:
+    session: AsyncSession, settings: Settings, user: dict
+) -> None:
     """Test ldapdelete on server."""
     dn = "cn=test,dc=md,dc=test"
 
     with tempfile.NamedTemporaryFile("w") as file:
-        file.write((
-            f"dn: {dn}\n"
-            "name: test\n"
-            "cn: test\n"
-            "objectClass: organization\n"
-            "objectClass: top\n"
-            "memberOf: cn=domain admins,cn=groups,dc=md,dc=test\n"
-        ))
+        file.write(
+            (
+                f"dn: {dn}\n"
+                "name: test\n"
+                "cn: test\n"
+                "objectClass: organization\n"
+                "objectClass: top\n"
+                "memberOf: cn=domain admins,cn=groups,dc=md,dc=test\n"
+            )
+        )
         file.seek(0)
         proc = await asyncio.create_subprocess_exec(
             "ldapadd",
-            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
-            "-f", file.name,
+            "-vvv",
+            "-H",
+            f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D",
+            user["sam_accout_name"],
+            "-x",
+            "-w",
+            user["password"],
+            "-f",
+            file.name,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
+            stderr=asyncio.subprocess.PIPE,
+        )
 
         assert await proc.wait() == 0
 
@@ -49,11 +60,18 @@ async def test_ldap_delete(
 
     proc = await asyncio.create_subprocess_exec(
         "ldapdelete",
-        "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-        "-D", user["sam_accout_name"], "-x", "-w", user["password"],
+        "-vvv",
+        "-H",
+        f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D",
+        user["sam_accout_name"],
+        "-x",
+        "-w",
+        user["password"],
         dn,
         stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE)
+        stderr=asyncio.subprocess.PIPE,
+    )
 
     assert await proc.wait() == 0
     assert not await session.scalar(
@@ -64,37 +82,55 @@ async def test_ldap_delete(
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("setup_session")
 async def test_ldap_delete_w_access_control(
-        session: AsyncSession, settings: Settings, creds: TestCreds) -> None:
+    session: AsyncSession, settings: Settings, creds: TestCreds
+) -> None:
     """Test ldapadd on server."""
     dn = "cn=test,dc=md,dc=test"
 
     with tempfile.NamedTemporaryFile("w") as file:
-        file.write((
-            f"dn: {dn}\n"
-            "name: test\n"
-            "cn: test\n"
-            "objectClass: organization\n"
-            "objectClass: top\n"
-        ))
+        file.write(
+            (
+                f"dn: {dn}\n"
+                "name: test\n"
+                "cn: test\n"
+                "objectClass: organization\n"
+                "objectClass: top\n"
+            )
+        )
         file.seek(0)
         proc = await asyncio.create_subprocess_exec(  # Add as Admin
             "ldapadd",
-            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-            "-D", creds.un, "-x", "-w", creds.pw,
-            "-f", file.name,
+            "-vvv",
+            "-H",
+            f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D",
+            creds.un,
+            "-x",
+            "-w",
+            creds.pw,
+            "-f",
+            file.name,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
+            stderr=asyncio.subprocess.PIPE,
+        )
 
         assert await proc.wait() == LDAPCodes.SUCCESS
 
     async def try_delete() -> int:
         proc = await asyncio.create_subprocess_exec(
             "ldapdelete",
-            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-            "-D", "user_non_admin", "-x", "-w", creds.pw,
+            "-vvv",
+            "-H",
+            f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D",
+            "user_non_admin",
+            "-x",
+            "-w",
+            creds.pw,
             dn,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
+            stderr=asyncio.subprocess.PIPE,
+        )
 
         return await proc.wait()
 
@@ -128,12 +164,20 @@ async def test_ldap_delete_w_access_control(
 
     proc = await asyncio.create_subprocess_exec(
         "ldapsearch",
-        "-vvv", "-x", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-        "-D", "user_non_admin",
-        "-w", creds.pw,
-        "-b", "dc=md,dc=test", "objectclass=*",
+        "-vvv",
+        "-x",
+        "-H",
+        f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D",
+        "user_non_admin",
+        "-w",
+        creds.pw,
+        "-b",
+        "dc=md,dc=test",
+        "objectclass=*",
         stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE)
+        stderr=asyncio.subprocess.PIPE,
+    )
 
     raw_data, _ = await proc.communicate()
     data = raw_data.decode().split("\n")

--- a/tests/test_ldap/test_util/test_delete.py
+++ b/tests/test_ldap/test_util/test_delete.py
@@ -19,7 +19,7 @@ from tests.conftest import TestCreds
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_ldap_delete(
         session: AsyncSession, settings: Settings, user: dict) -> None:
     """Test ldapdelete on server."""
@@ -36,10 +36,10 @@ async def test_ldap_delete(
         ))
         file.seek(0)
         proc = await asyncio.create_subprocess_exec(
-            'ldapadd',
-            '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-            '-D', user['sam_accout_name'], '-x', '-w', user['password'],
-            '-f', file.name,
+            "ldapadd",
+            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
+            "-f", file.name,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE)
 
@@ -48,9 +48,9 @@ async def test_ldap_delete(
     assert await session.scalar(select(Directory).filter_by(name="test"))
 
     proc = await asyncio.create_subprocess_exec(
-        'ldapdelete',
-        '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-        '-D', user['sam_accout_name'], '-x', '-w', user['password'],
+        "ldapdelete",
+        "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D", user["sam_accout_name"], "-x", "-w", user["password"],
         dn,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE)
@@ -62,11 +62,11 @@ async def test_ldap_delete(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_ldap_delete_w_access_control(
         session: AsyncSession, settings: Settings, creds: TestCreds) -> None:
     """Test ldapadd on server."""
-    dn = 'cn=test,dc=md,dc=test'
+    dn = "cn=test,dc=md,dc=test"
 
     with tempfile.NamedTemporaryFile("w") as file:
         file.write((
@@ -78,10 +78,10 @@ async def test_ldap_delete_w_access_control(
         ))
         file.seek(0)
         proc = await asyncio.create_subprocess_exec(  # Add as Admin
-            'ldapadd',
-            '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-            '-D', creds.un, '-x', '-w', creds.pw,
-            '-f', file.name,
+            "ldapadd",
+            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D", creds.un, "-x", "-w", creds.pw,
+            "-f", file.name,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE)
 
@@ -89,9 +89,9 @@ async def test_ldap_delete_w_access_control(
 
     async def try_delete() -> int:
         proc = await asyncio.create_subprocess_exec(
-            'ldapdelete',
-            '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-            '-D', "user_non_admin", '-x', '-w', creds.pw,
+            "ldapdelete",
+            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D", "user_non_admin", "-x", "-w", creds.pw,
             dn,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE)
@@ -101,7 +101,7 @@ async def test_ldap_delete_w_access_control(
     assert await try_delete() == LDAPCodes.NO_SUCH_OBJECT
 
     await create_access_policy(
-        name='TEST Read Access Policy',
+        name="TEST Read Access Policy",
         can_add=False,
         can_modify=False,
         can_read=True,
@@ -114,7 +114,7 @@ async def test_ldap_delete_w_access_control(
     assert await try_delete() == LDAPCodes.INSUFFICIENT_ACCESS_RIGHTS
 
     await create_access_policy(
-        name='TEST Del Access Policy',
+        name="TEST Del Access Policy",
         can_add=False,
         can_modify=False,
         can_read=True,
@@ -127,19 +127,19 @@ async def test_ldap_delete_w_access_control(
     assert await try_delete() == LDAPCodes.SUCCESS
 
     proc = await asyncio.create_subprocess_exec(
-        'ldapsearch',
-        '-vvv', '-x', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-        '-D', 'user_non_admin',
-        '-w', creds.pw,
-        '-b', 'dc=md,dc=test', 'objectclass=*',
+        "ldapsearch",
+        "-vvv", "-x", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D", "user_non_admin",
+        "-w", creds.pw,
+        "-b", "dc=md,dc=test", "objectclass=*",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE)
 
     raw_data, _ = await proc.communicate()
-    data = raw_data.decode().split('\n')
+    data = raw_data.decode().split("\n")
     result = await proc.wait()
 
-    dn_list = [d.removeprefix("dn: ") for d in data if d.startswith('dn:')]
+    dn_list = [d.removeprefix("dn: ") for d in data if d.startswith("dn:")]
 
     assert result == 0
     assert dn not in dn_list

--- a/tests/test_ldap/test_util/test_modify.py
+++ b/tests/test_ldap/test_util/test_modify.py
@@ -22,7 +22,7 @@ from tests.conftest import TestCreds
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_ldap_base_modify(
         session: AsyncSession, settings: Settings, user: dict) -> None:
     """Test ldapmodify on server."""
@@ -43,8 +43,8 @@ async def test_ldap_base_modify(
     for attr in directory.attributes:
         attributes[attr.name].append(attr.value)
 
-    assert 'user' in attributes['objectClass']
-    assert attributes['posixEmail'] == ["abctest@mail.com"]
+    assert "user" in attributes["objectClass"]
+    assert attributes["posixEmail"] == ["abctest@mail.com"]
 
     with tempfile.NamedTemporaryFile("w") as file:
         file.write((
@@ -67,10 +67,10 @@ async def test_ldap_base_modify(
         ))
         file.seek(0)
         proc = await asyncio.create_subprocess_exec(
-            'ldapmodify',
-            '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-            '-D', user['sam_accout_name'], '-x', '-w', user['password'],
-            '-f', file.name,
+            "ldapmodify",
+            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
+            "-f", file.name,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE)
 
@@ -85,21 +85,21 @@ async def test_ldap_base_modify(
     for attr in directory.attributes:
         attributes[attr.name].append(attr.value)
 
-    assert attributes['objectClass'] == [
-        'top', 'person',
-        'organizationalPerson', 'posixAccount', 'user']
-    assert attributes['title'] == [
+    assert attributes["objectClass"] == [
+        "top", "person",
+        "organizationalPerson", "posixAccount", "user"]
+    assert attributes["title"] == [
         "Grand Poobah", "Grand Poobah1",
         "Grand Poobah2", "Grand Poobah3",
     ]
-    assert attributes['jpegPhoto'] == ['modme.jpeg']
+    assert attributes["jpegPhoto"] == ["modme.jpeg"]
     assert directory.user.mail == "modme@student.of.life.edu"
 
-    assert 'posixEmail' not in attributes
+    assert "posixEmail" not in attributes
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_ldap_membersip_user_delete(
         session: AsyncSession, settings: Settings, user: dict) -> None:
     """Test ldapmodify on server."""
@@ -122,10 +122,10 @@ async def test_ldap_membersip_user_delete(
         ))
         file.seek(0)
         proc = await asyncio.create_subprocess_exec(
-            'ldapmodify',
-            '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-            '-D', user['sam_accout_name'], '-x', '-w', user['password'],
-            '-f', file.name,
+            "ldapmodify",
+            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
+            "-f", file.name,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE)
 
@@ -139,12 +139,12 @@ async def test_ldap_membersip_user_delete(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_ldap_membersip_user_add(
         session: AsyncSession, settings: Settings, creds: TestCreds) -> None:
     """Test ldapmodify on server."""
     dn = "cn=user_non_admin,ou=users,dc=md,dc=test"
-    query = (  # noqa
+    query = (
         select(Directory)
         .options(selectinload(Directory.groups).selectinload(Group.directory))
         .filter(Directory.path == get_search_path(dn)))
@@ -166,10 +166,10 @@ async def test_ldap_membersip_user_add(
         ))
         file.seek(0)
         proc = await asyncio.create_subprocess_exec(
-            'ldapmodify',
-            '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-            '-D', creds.un, '-x', '-w', creds.pw,
-            '-f', file.name,
+            "ldapmodify",
+            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D", creds.un, "-x", "-w", creds.pw,
+            "-f", file.name,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE)
 
@@ -183,7 +183,7 @@ async def test_ldap_membersip_user_add(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_ldap_membersip_user_replace(
         session: AsyncSession, settings: Settings, user: dict) -> None:
     """Test ldapmodify on server."""
@@ -210,10 +210,10 @@ async def test_ldap_membersip_user_replace(
         ))
         file.seek(0)
         proc = await asyncio.create_subprocess_exec(
-            'ldapadd',
-            '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-            '-D', user['sam_accout_name'], '-x', '-w', user['password'],
-            '-f', file.name,
+            "ldapadd",
+            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
+            "-f", file.name,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE)
 
@@ -231,10 +231,10 @@ async def test_ldap_membersip_user_replace(
         ))
         file.seek(0)
         proc = await asyncio.create_subprocess_exec(
-            'ldapmodify',
-            '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-            '-D', user['sam_accout_name'], '-x', '-w', user['password'],
-            '-f', file.name,
+            "ldapmodify",
+            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
+            "-f", file.name,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE)
 
@@ -248,13 +248,13 @@ async def test_ldap_membersip_user_replace(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_ldap_membersip_grp_replace(
         session: AsyncSession, settings: Settings, user: dict) -> None:
     """Test ldapmodify on server."""
     dn = "cn=domain admins,cn=groups,dc=md,dc=test"
 
-    query = (  # noqa
+    query = (
         select(Directory)
         .options(
             selectinload(Directory.group)
@@ -279,10 +279,10 @@ async def test_ldap_membersip_grp_replace(
         ))
         file.seek(0)
         proc = await asyncio.create_subprocess_exec(
-            'ldapadd',
-            '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-            '-D', user['sam_accout_name'], '-x', '-w', user['password'],
-            '-f', file.name,
+            "ldapadd",
+            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
+            "-f", file.name,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE)
 
@@ -300,10 +300,10 @@ async def test_ldap_membersip_grp_replace(
         ))
         file.seek(0)
         proc = await asyncio.create_subprocess_exec(
-            'ldapmodify',
-            '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-            '-D', user['sam_accout_name'], '-x', '-w', user['password'],
-            '-f', file.name,
+            "ldapmodify",
+            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
+            "-f", file.name,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE)
         result = await proc.wait()
@@ -317,7 +317,7 @@ async def test_ldap_membersip_grp_replace(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_ldap_modify_dn(
         session: AsyncSession, settings: Settings, user: dict) -> None:
     """Test ldapmodify on server."""
@@ -333,10 +333,10 @@ async def test_ldap_modify_dn(
         ))
         file.seek(0)
         proc = await asyncio.create_subprocess_exec(
-            'ldapmodify',
-            '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-            '-D', user['sam_accout_name'], '-x', '-w', user['password'],
-            '-f', file.name,
+            "ldapmodify",
+            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
+            "-f", file.name,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE)
 
@@ -350,8 +350,8 @@ async def test_ldap_modify_dn(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('_force_override_tls')
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("_force_override_tls")
 async def test_ldap_modify_password_change(
         settings: Settings, creds: TestCreds) -> None:
     """Test ldapmodify on server."""
@@ -368,10 +368,10 @@ async def test_ldap_modify_password_change(
         ))
         file.seek(0)
         proc = await asyncio.create_subprocess_exec(
-            'ldapmodify',
-            '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-            '-D', creds.un, '-x', '-w', creds.pw,
-            '-f', file.name,
+            "ldapmodify",
+            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D", creds.un, "-x", "-w", creds.pw,
+            "-f", file.name,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE)
 
@@ -380,16 +380,16 @@ async def test_ldap_modify_password_change(
     assert result == 0
 
     proc = await asyncio.create_subprocess_exec(
-        'ldapsearch',
-        '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-        '-D', creds.un, '-x', '-w', new_password)
+        "ldapsearch",
+        "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D", creds.un, "-x", "-w", new_password)
 
     result = await proc.wait()
     assert result == 0
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_ldap_modify_with_ap(
         session: AsyncSession, settings: Settings, creds: TestCreds) -> None:
     """Test ldapmodify on server."""
@@ -427,10 +427,10 @@ async def test_ldap_modify_with_ap(
             ))
             file.seek(0)
             proc = await asyncio.create_subprocess_exec(
-                'ldapmodify',
-                '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-                '-D', "user_non_admin", '-x', '-w', creds.pw,
-                '-f', file.name,
+                "ldapmodify",
+                "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+                "-D", "user_non_admin", "-x", "-w", creds.pw,
+                "-f", file.name,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE)
 
@@ -439,7 +439,7 @@ async def test_ldap_modify_with_ap(
     assert await try_modify() == LDAPCodes.INSUFFICIENT_ACCESS_RIGHTS
 
     await create_access_policy(
-        name='TEST read Access Policy',
+        name="TEST read Access Policy",
         can_add=False,
         can_modify=False,
         can_read=True,
@@ -452,7 +452,7 @@ async def test_ldap_modify_with_ap(
     assert await try_modify() == LDAPCodes.INSUFFICIENT_ACCESS_RIGHTS
 
     await create_access_policy(
-        name='TEST modify Access Policy',
+        name="TEST modify Access Policy",
         can_add=False,
         can_modify=True,
         can_read=True,
@@ -473,13 +473,13 @@ async def test_ldap_modify_with_ap(
     for attr in directory.attributes:
         attributes[attr.name].append(attr.value)
 
-    assert attributes['objectClass'] == [
-        'top', 'container', 'organizationalUnit']
-    assert attributes['title'] == [
+    assert attributes["objectClass"] == [
+        "top", "container", "organizationalUnit"]
+    assert attributes["title"] == [
         "Grand Poobah", "Grand Poobah1",
         "Grand Poobah2", "Grand Poobah3",
     ]
-    assert attributes['jpegPhoto'] == ['modme.jpeg']
+    assert attributes["jpegPhoto"] == ["modme.jpeg"]
     assert directory.user.mail == "modme@student.of.life.edu"
 
-    assert 'posixEmail' not in attributes
+    assert "posixEmail" not in attributes

--- a/tests/test_ldap/test_util/test_modify.py
+++ b/tests/test_ldap/test_util/test_modify.py
@@ -24,15 +24,17 @@ from tests.conftest import TestCreds
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("setup_session")
 async def test_ldap_base_modify(
-        session: AsyncSession, settings: Settings, user: dict) -> None:
+    session: AsyncSession, settings: Settings, user: dict
+) -> None:
     """Test ldapmodify on server."""
     dn = "cn=user0,ou=users,dc=md,dc=test"
     query = (
         select(Directory)
         .options(
-            subqueryload(Directory.attributes),
-            joinedload(Directory.user))
-        .filter(Directory.path == get_search_path(dn)))
+            subqueryload(Directory.attributes), joinedload(Directory.user)
+        )
+        .filter(Directory.path == get_search_path(dn))
+    )
 
     directory = (await session.scalars(query)).one()
 
@@ -47,367 +49,8 @@ async def test_ldap_base_modify(
     assert attributes["posixEmail"] == ["abctest@mail.com"]
 
     with tempfile.NamedTemporaryFile("w") as file:
-        file.write((
-            f"dn: {dn}\n"
-            "changetype: modify\n"
-            "replace: mail\n"
-            "mail: modme@student.of.life.edu\n"
-            "-\n"
-            "add: title\n"
-            "title: Grand Poobah\n"
-            "title: Grand Poobah1\n"
-            "title: Grand Poobah2\n"
-            "title: Grand Poobah3\n"
-            "-\n"
-            "add: jpegPhoto\n"
-            "jpegPhoto: modme.jpeg\n"
-            "-\n"
-            "delete: posixEmail\n"
-            "-\n"
-        ))
-        file.seek(0)
-        proc = await asyncio.create_subprocess_exec(
-            "ldapmodify",
-            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
-            "-f", file.name,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
-
-        result = await proc.wait()
-
-    assert result == 0
-    session.expire_all()
-    directory = (await session.scalars(query)).one()
-
-    attributes = defaultdict(list)
-
-    for attr in directory.attributes:
-        attributes[attr.name].append(attr.value)
-
-    assert attributes["objectClass"] == [
-        "top", "person",
-        "organizationalPerson", "posixAccount", "user"]
-    assert attributes["title"] == [
-        "Grand Poobah", "Grand Poobah1",
-        "Grand Poobah2", "Grand Poobah3",
-    ]
-    assert attributes["jpegPhoto"] == ["modme.jpeg"]
-    assert directory.user.mail == "modme@student.of.life.edu"
-
-    assert "posixEmail" not in attributes
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("setup_session")
-async def test_ldap_membersip_user_delete(
-        session: AsyncSession, settings: Settings, user: dict) -> None:
-    """Test ldapmodify on server."""
-    dn = "cn=user0,ou=users,dc=md,dc=test"
-    query = (
-        select(Directory)
-        .options(selectinload(Directory.groups))
-        .filter(Directory.path == get_search_path(dn)))
-
-    directory = (await session.scalars(query)).one()
-
-    assert directory.groups
-
-    with tempfile.NamedTemporaryFile("w") as file:
-        file.write((
-            f"dn: {dn}\n"
-            "changetype: modify\n"
-            "delete: memberOf\n"
-            "-\n"
-        ))
-        file.seek(0)
-        proc = await asyncio.create_subprocess_exec(
-            "ldapmodify",
-            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
-            "-f", file.name,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
-
-        result = await proc.wait()
-
-    assert result == 0
-
-    session.expire_all()
-    directory = (await session.scalars(query)).one()
-    assert not directory.groups
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("setup_session")
-async def test_ldap_membersip_user_add(
-        session: AsyncSession, settings: Settings, creds: TestCreds) -> None:
-    """Test ldapmodify on server."""
-    dn = "cn=user_non_admin,ou=users,dc=md,dc=test"
-    query = (
-        select(Directory)
-        .options(selectinload(Directory.groups).selectinload(Group.directory))
-        .filter(Directory.path == get_search_path(dn)))
-
-    directory = (await session.scalars(query)).one()
-
-    directory.groups.clear()
-    await session.commit()
-
-    assert not directory.groups
-
-    with tempfile.NamedTemporaryFile("w") as file:
-        file.write((
-            f"dn: {dn}\n"
-            "changetype: modify\n"
-            "add: memberOf\n"
-            "memberOf: cn=domain admins,cn=groups,dc=md,dc=test\n"
-            "-\n"
-        ))
-        file.seek(0)
-        proc = await asyncio.create_subprocess_exec(
-            "ldapmodify",
-            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-            "-D", creds.un, "-x", "-w", creds.pw,
-            "-f", file.name,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
-
-        result = await proc.wait()
-
-    session.expire_all()
-
-    assert result == 0
-    directory = (await session.scalars(query)).one()
-    assert directory.groups
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("setup_session")
-async def test_ldap_membersip_user_replace(
-        session: AsyncSession, settings: Settings, user: dict) -> None:
-    """Test ldapmodify on server."""
-    dn = "cn=user0,ou=users,dc=md,dc=test"
-    query = (
-        select(Directory)
-        .options(selectinload(Directory.groups))
-        .filter(Directory.path == get_search_path(dn)))
-    directory = (await session.scalars(query)).one()
-
-    assert directory.groups
-
-    new_group_dn = "cn=twisted,cn=groups,dc=md,dc=test\n"
-
-    # add new group
-    with tempfile.NamedTemporaryFile("w") as file:
-        file.write((
-            f"dn: {new_group_dn}"
-            "name: twisted\n"
-            "cn: twisted\n"
-            "objectClass: group\n"
-            "objectClass: top\n"
-            "memberOf: cn=domain admins,cn=groups,dc=md,dc=test\n"
-        ))
-        file.seek(0)
-        proc = await asyncio.create_subprocess_exec(
-            "ldapadd",
-            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
-            "-f", file.name,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
-
-        result = await proc.wait()
-
-        assert result == 0
-
-    with tempfile.NamedTemporaryFile("w") as file:
-        file.write((
-            f"dn: {dn}\n"
-            "changetype: modify\n"
-            "replace: memberOf\n"
-            "memberOf: cn=twisted,cn=groups,dc=md,dc=test\n"
-            "-\n"
-        ))
-        file.seek(0)
-        proc = await asyncio.create_subprocess_exec(
-            "ldapmodify",
-            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
-            "-f", file.name,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
-
-        result = await proc.wait()
-
-    assert result == 0
-    session.expire_all()
-
-    directory = (await session.scalars(query)).one()
-    assert directory.groups
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("setup_session")
-async def test_ldap_membersip_grp_replace(
-        session: AsyncSession, settings: Settings, user: dict) -> None:
-    """Test ldapmodify on server."""
-    dn = "cn=domain admins,cn=groups,dc=md,dc=test"
-
-    query = (
-        select(Directory)
-        .options(
-            selectinload(Directory.group)
-            .selectinload(Group.parent_groups)
-            .selectinload(Group.directory))
-        .filter(Directory.path == get_search_path(dn))
-    )
-
-    directory = await session.scalar(query)
-
-    assert directory
-    assert not directory.group.parent_groups
-
-    # add new group
-    with tempfile.NamedTemporaryFile("w") as file:
-        file.write((
-            "dn: cn=twisted1,cn=groups,dc=md,dc=test\n"
-            "name: twisted\n"
-            "cn: twisted\n"
-            "objectClass: group\n"
-            "objectClass: top\n"
-        ))
-        file.seek(0)
-        proc = await asyncio.create_subprocess_exec(
-            "ldapadd",
-            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
-            "-f", file.name,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
-
-        result = await proc.wait()
-
-        assert result == 0
-
-    with tempfile.NamedTemporaryFile("w") as file:
-        file.write((
-            f"dn: {dn}\n"
-            "changetype: modify\n"
-            "replace: memberOf\n"
-            "memberOf: cn=twisted1,cn=groups,dc=md,dc=test\n"
-            "-\n"
-        ))
-        file.seek(0)
-        proc = await asyncio.create_subprocess_exec(
-            "ldapmodify",
-            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
-            "-f", file.name,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
-        result = await proc.wait()
-
-        assert result == 0
-
-    session.expire_all()
-    directory = await session.scalar(query)
-    assert directory
-    assert directory.group.parent_groups[0].directory.name == "twisted1"
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("setup_session")
-async def test_ldap_modify_dn(
-        session: AsyncSession, settings: Settings, user: dict) -> None:
-    """Test ldapmodify on server."""
-    dn = "cn=user0,ou=users,dc=md,dc=test"
-
-    with tempfile.NamedTemporaryFile("w") as file:
-        file.write((
-            f"dn: {dn}\n"
-            "changetype: modrdn\n"
-            "newrdn: cn=user2\n"
-            "deleteoldrdn: 1\n"
-            "newsuperior: ou=users,dc=md,dc=test\n"
-        ))
-        file.seek(0)
-        proc = await asyncio.create_subprocess_exec(
-            "ldapmodify",
-            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-            "-D", user["sam_accout_name"], "-x", "-w", user["password"],
-            "-f", file.name,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
-
-        res = await proc.wait()
-        assert res == 0
-
-    assert await session.scalar(
-        select(Directory)
-        .filter(Directory.path ==
-                ["dc=test", "dc=md", "ou=users", "cn=user2"]))
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("setup_session")
-@pytest.mark.usefixtures("_force_override_tls")
-async def test_ldap_modify_password_change(
-        settings: Settings, creds: TestCreds) -> None:
-    """Test ldapmodify on server."""
-    dn = "cn=user0,ou=users,dc=md,dc=test"
-    new_password = "Password12345"  # noqa
-
-    with tempfile.NamedTemporaryFile("w") as file:
-        file.write((
-            f"dn: {dn}\n"
-            "changetype: modify\n"
-            "replace: userPassword\n"
-            f"userPassword: {new_password}\n"
-            "-\n"
-        ))
-        file.seek(0)
-        proc = await asyncio.create_subprocess_exec(
-            "ldapmodify",
-            "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-            "-D", creds.un, "-x", "-w", creds.pw,
-            "-f", file.name,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
-
-        result = await proc.wait()
-
-    assert result == 0
-
-    proc = await asyncio.create_subprocess_exec(
-        "ldapsearch",
-        "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-        "-D", creds.un, "-x", "-w", new_password)
-
-    result = await proc.wait()
-    assert result == 0
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("setup_session")
-async def test_ldap_modify_with_ap(
-        session: AsyncSession, settings: Settings, creds: TestCreds) -> None:
-    """Test ldapmodify on server."""
-    dn = "ou=users,dc=md,dc=test"
-    search_path = get_search_path(dn)
-
-    query = (
-        select(Directory)
-        .options(
-            subqueryload(Directory.attributes),
-            joinedload(Directory.user))
-        .filter(Directory.path == search_path))
-
-    directory = await session.scalar(query)
-
-    async def try_modify() -> int:
-        with tempfile.NamedTemporaryFile("w") as file:
-            file.write((
+        file.write(
+            (
                 f"dn: {dn}\n"
                 "changetype: modify\n"
                 "replace: mail\n"
@@ -424,15 +67,493 @@ async def test_ldap_modify_with_ap(
                 "-\n"
                 "delete: posixEmail\n"
                 "-\n"
-            ))
+            )
+        )
+        file.seek(0)
+        proc = await asyncio.create_subprocess_exec(
+            "ldapmodify",
+            "-vvv",
+            "-H",
+            f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D",
+            user["sam_accout_name"],
+            "-x",
+            "-w",
+            user["password"],
+            "-f",
+            file.name,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        result = await proc.wait()
+
+    assert result == 0
+    session.expire_all()
+    directory = (await session.scalars(query)).one()
+
+    attributes = defaultdict(list)
+
+    for attr in directory.attributes:
+        attributes[attr.name].append(attr.value)
+
+    assert attributes["objectClass"] == [
+        "top",
+        "person",
+        "organizationalPerson",
+        "posixAccount",
+        "user",
+    ]
+    assert attributes["title"] == [
+        "Grand Poobah",
+        "Grand Poobah1",
+        "Grand Poobah2",
+        "Grand Poobah3",
+    ]
+    assert attributes["jpegPhoto"] == ["modme.jpeg"]
+    assert directory.user.mail == "modme@student.of.life.edu"
+
+    assert "posixEmail" not in attributes
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("setup_session")
+async def test_ldap_membersip_user_delete(
+    session: AsyncSession, settings: Settings, user: dict
+) -> None:
+    """Test ldapmodify on server."""
+    dn = "cn=user0,ou=users,dc=md,dc=test"
+    query = (
+        select(Directory)
+        .options(selectinload(Directory.groups))
+        .filter(Directory.path == get_search_path(dn))
+    )
+
+    directory = (await session.scalars(query)).one()
+
+    assert directory.groups
+
+    with tempfile.NamedTemporaryFile("w") as file:
+        file.write((f"dn: {dn}\nchangetype: modify\ndelete: memberOf\n-\n"))
+        file.seek(0)
+        proc = await asyncio.create_subprocess_exec(
+            "ldapmodify",
+            "-vvv",
+            "-H",
+            f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D",
+            user["sam_accout_name"],
+            "-x",
+            "-w",
+            user["password"],
+            "-f",
+            file.name,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        result = await proc.wait()
+
+    assert result == 0
+
+    session.expire_all()
+    directory = (await session.scalars(query)).one()
+    assert not directory.groups
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("setup_session")
+async def test_ldap_membersip_user_add(
+    session: AsyncSession, settings: Settings, creds: TestCreds
+) -> None:
+    """Test ldapmodify on server."""
+    dn = "cn=user_non_admin,ou=users,dc=md,dc=test"
+    query = (
+        select(Directory)
+        .options(selectinload(Directory.groups).selectinload(Group.directory))
+        .filter(Directory.path == get_search_path(dn))
+    )
+
+    directory = (await session.scalars(query)).one()
+
+    directory.groups.clear()
+    await session.commit()
+
+    assert not directory.groups
+
+    with tempfile.NamedTemporaryFile("w") as file:
+        file.write(
+            (
+                f"dn: {dn}\n"
+                "changetype: modify\n"
+                "add: memberOf\n"
+                "memberOf: cn=domain admins,cn=groups,dc=md,dc=test\n"
+                "-\n"
+            )
+        )
+        file.seek(0)
+        proc = await asyncio.create_subprocess_exec(
+            "ldapmodify",
+            "-vvv",
+            "-H",
+            f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D",
+            creds.un,
+            "-x",
+            "-w",
+            creds.pw,
+            "-f",
+            file.name,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        result = await proc.wait()
+
+    session.expire_all()
+
+    assert result == 0
+    directory = (await session.scalars(query)).one()
+    assert directory.groups
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("setup_session")
+async def test_ldap_membersip_user_replace(
+    session: AsyncSession, settings: Settings, user: dict
+) -> None:
+    """Test ldapmodify on server."""
+    dn = "cn=user0,ou=users,dc=md,dc=test"
+    query = (
+        select(Directory)
+        .options(selectinload(Directory.groups))
+        .filter(Directory.path == get_search_path(dn))
+    )
+    directory = (await session.scalars(query)).one()
+
+    assert directory.groups
+
+    new_group_dn = "cn=twisted,cn=groups,dc=md,dc=test\n"
+
+    # add new group
+    with tempfile.NamedTemporaryFile("w") as file:
+        file.write(
+            (
+                f"dn: {new_group_dn}"
+                "name: twisted\n"
+                "cn: twisted\n"
+                "objectClass: group\n"
+                "objectClass: top\n"
+                "memberOf: cn=domain admins,cn=groups,dc=md,dc=test\n"
+            )
+        )
+        file.seek(0)
+        proc = await asyncio.create_subprocess_exec(
+            "ldapadd",
+            "-vvv",
+            "-H",
+            f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D",
+            user["sam_accout_name"],
+            "-x",
+            "-w",
+            user["password"],
+            "-f",
+            file.name,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        result = await proc.wait()
+
+        assert result == 0
+
+    with tempfile.NamedTemporaryFile("w") as file:
+        file.write(
+            (
+                f"dn: {dn}\n"
+                "changetype: modify\n"
+                "replace: memberOf\n"
+                "memberOf: cn=twisted,cn=groups,dc=md,dc=test\n"
+                "-\n"
+            )
+        )
+        file.seek(0)
+        proc = await asyncio.create_subprocess_exec(
+            "ldapmodify",
+            "-vvv",
+            "-H",
+            f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D",
+            user["sam_accout_name"],
+            "-x",
+            "-w",
+            user["password"],
+            "-f",
+            file.name,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        result = await proc.wait()
+
+    assert result == 0
+    session.expire_all()
+
+    directory = (await session.scalars(query)).one()
+    assert directory.groups
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("setup_session")
+async def test_ldap_membersip_grp_replace(
+    session: AsyncSession, settings: Settings, user: dict
+) -> None:
+    """Test ldapmodify on server."""
+    dn = "cn=domain admins,cn=groups,dc=md,dc=test"
+
+    query = (
+        select(Directory)
+        .options(
+            selectinload(Directory.group)
+            .selectinload(Group.parent_groups)
+            .selectinload(Group.directory)
+        )
+        .filter(Directory.path == get_search_path(dn))
+    )
+
+    directory = await session.scalar(query)
+
+    assert directory
+    assert not directory.group.parent_groups
+
+    # add new group
+    with tempfile.NamedTemporaryFile("w") as file:
+        file.write(
+            (
+                "dn: cn=twisted1,cn=groups,dc=md,dc=test\n"
+                "name: twisted\n"
+                "cn: twisted\n"
+                "objectClass: group\n"
+                "objectClass: top\n"
+            )
+        )
+        file.seek(0)
+        proc = await asyncio.create_subprocess_exec(
+            "ldapadd",
+            "-vvv",
+            "-H",
+            f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D",
+            user["sam_accout_name"],
+            "-x",
+            "-w",
+            user["password"],
+            "-f",
+            file.name,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        result = await proc.wait()
+
+        assert result == 0
+
+    with tempfile.NamedTemporaryFile("w") as file:
+        file.write(
+            (
+                f"dn: {dn}\n"
+                "changetype: modify\n"
+                "replace: memberOf\n"
+                "memberOf: cn=twisted1,cn=groups,dc=md,dc=test\n"
+                "-\n"
+            )
+        )
+        file.seek(0)
+        proc = await asyncio.create_subprocess_exec(
+            "ldapmodify",
+            "-vvv",
+            "-H",
+            f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D",
+            user["sam_accout_name"],
+            "-x",
+            "-w",
+            user["password"],
+            "-f",
+            file.name,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        result = await proc.wait()
+
+        assert result == 0
+
+    session.expire_all()
+    directory = await session.scalar(query)
+    assert directory
+    assert directory.group.parent_groups[0].directory.name == "twisted1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("setup_session")
+async def test_ldap_modify_dn(
+    session: AsyncSession, settings: Settings, user: dict
+) -> None:
+    """Test ldapmodify on server."""
+    dn = "cn=user0,ou=users,dc=md,dc=test"
+
+    with tempfile.NamedTemporaryFile("w") as file:
+        file.write(
+            (
+                f"dn: {dn}\n"
+                "changetype: modrdn\n"
+                "newrdn: cn=user2\n"
+                "deleteoldrdn: 1\n"
+                "newsuperior: ou=users,dc=md,dc=test\n"
+            )
+        )
+        file.seek(0)
+        proc = await asyncio.create_subprocess_exec(
+            "ldapmodify",
+            "-vvv",
+            "-H",
+            f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D",
+            user["sam_accout_name"],
+            "-x",
+            "-w",
+            user["password"],
+            "-f",
+            file.name,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        res = await proc.wait()
+        assert res == 0
+
+    assert await session.scalar(
+        select(Directory).filter(
+            Directory.path == ["dc=test", "dc=md", "ou=users", "cn=user2"]
+        )
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("_force_override_tls")
+async def test_ldap_modify_password_change(
+    settings: Settings, creds: TestCreds
+) -> None:
+    """Test ldapmodify on server."""
+    dn = "cn=user0,ou=users,dc=md,dc=test"
+    new_password = "Password12345"  # noqa
+
+    with tempfile.NamedTemporaryFile("w") as file:
+        file.write(
+            (
+                f"dn: {dn}\n"
+                "changetype: modify\n"
+                "replace: userPassword\n"
+                f"userPassword: {new_password}\n"
+                "-\n"
+            )
+        )
+        file.seek(0)
+        proc = await asyncio.create_subprocess_exec(
+            "ldapmodify",
+            "-vvv",
+            "-H",
+            f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D",
+            creds.un,
+            "-x",
+            "-w",
+            creds.pw,
+            "-f",
+            file.name,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        result = await proc.wait()
+
+    assert result == 0
+
+    proc = await asyncio.create_subprocess_exec(
+        "ldapsearch",
+        "-vvv",
+        "-H",
+        f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D",
+        creds.un,
+        "-x",
+        "-w",
+        new_password,
+    )
+
+    result = await proc.wait()
+    assert result == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("setup_session")
+async def test_ldap_modify_with_ap(
+    session: AsyncSession, settings: Settings, creds: TestCreds
+) -> None:
+    """Test ldapmodify on server."""
+    dn = "ou=users,dc=md,dc=test"
+    search_path = get_search_path(dn)
+
+    query = (
+        select(Directory)
+        .options(
+            subqueryload(Directory.attributes), joinedload(Directory.user)
+        )
+        .filter(Directory.path == search_path)
+    )
+
+    directory = await session.scalar(query)
+
+    async def try_modify() -> int:
+        with tempfile.NamedTemporaryFile("w") as file:
+            file.write(
+                (
+                    f"dn: {dn}\n"
+                    "changetype: modify\n"
+                    "replace: mail\n"
+                    "mail: modme@student.of.life.edu\n"
+                    "-\n"
+                    "add: title\n"
+                    "title: Grand Poobah\n"
+                    "title: Grand Poobah1\n"
+                    "title: Grand Poobah2\n"
+                    "title: Grand Poobah3\n"
+                    "-\n"
+                    "add: jpegPhoto\n"
+                    "jpegPhoto: modme.jpeg\n"
+                    "-\n"
+                    "delete: posixEmail\n"
+                    "-\n"
+                )
+            )
             file.seek(0)
             proc = await asyncio.create_subprocess_exec(
                 "ldapmodify",
-                "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-                "-D", "user_non_admin", "-x", "-w", creds.pw,
-                "-f", file.name,
+                "-vvv",
+                "-H",
+                f"ldap://{settings.HOST}:{settings.PORT}",
+                "-D",
+                "user_non_admin",
+                "-x",
+                "-w",
+                creds.pw,
+                "-f",
+                file.name,
                 stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE)
+                stderr=asyncio.subprocess.PIPE,
+            )
 
             return await proc.wait()
 
@@ -474,10 +595,15 @@ async def test_ldap_modify_with_ap(
         attributes[attr.name].append(attr.value)
 
     assert attributes["objectClass"] == [
-        "top", "container", "organizationalUnit"]
+        "top",
+        "container",
+        "organizationalUnit",
+    ]
     assert attributes["title"] == [
-        "Grand Poobah", "Grand Poobah1",
-        "Grand Poobah2", "Grand Poobah3",
+        "Grand Poobah",
+        "Grand Poobah1",
+        "Grand Poobah2",
+        "Grand Poobah3",
     ]
     assert attributes["jpegPhoto"] == ["modme.jpeg"]
     assert directory.user.mail == "modme@student.of.life.edu"

--- a/tests/test_ldap/test_util/test_search.py
+++ b/tests/test_ldap/test_util/test_search.py
@@ -25,21 +25,21 @@ from tests.conftest import TestCreds
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_ldap_search(settings: Settings, creds: TestCreds) -> None:
     """Test ldapsearch on server."""
     proc = await asyncio.create_subprocess_exec(
-        'ldapsearch',
-        '-vvv', '-x', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-        '-D', creds.un,
-        '-w', creds.pw,
-        '-b', 'dc=md,dc=test', 'objectclass=*',
+        "ldapsearch",
+        "-vvv", "-x", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D", creds.un,
+        "-w", creds.pw,
+        "-b", "dc=md,dc=test", "objectclass=*",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE)
 
     raw_data, _ = await proc.communicate()
-    data = raw_data.decode().split('\n')
+    data = raw_data.decode().split("\n")
     result = await proc.wait()
 
     assert result == 0
@@ -49,28 +49,28 @@ async def test_ldap_search(settings: Settings, creds: TestCreds) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_ldap_search_filter(
     settings: Settings, creds: TestCreds,
 ) -> None:
     """Test ldapsearch with filter on server."""
     proc = await asyncio.create_subprocess_exec(
-        'ldapsearch',
-        '-vvv', '-x', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-        '-D', creds.un,
-        '-w', creds.pw,
-        '-b', 'dc=md,dc=test',
-        '(&'
-        '(objectClass=user)'
-        '(memberOf:1.2.840.113556.1.4.1941:=cn=domain admins,cn=groups,dc=md,\
-            dc=test)'
-        ')',
+        "ldapsearch",
+        "-vvv", "-x", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D", creds.un,
+        "-w", creds.pw,
+        "-b", "dc=md,dc=test",
+        "(&"
+        "(objectClass=user)"
+        "(memberOf:1.2.840.113556.1.4.1941:=cn=domain admins,cn=groups,dc=md,\
+            dc=test)"
+        ")",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE)
 
     raw_data, _ = await proc.communicate()
-    data = raw_data.decode().split('\n')
+    data = raw_data.decode().split("\n")
     result = await proc.wait()
 
     assert result == 0
@@ -79,24 +79,24 @@ async def test_ldap_search_filter(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_ldap_search_filter_prefix(
     settings: Settings, creds: TestCreds,
 ) -> None:
     """Test ldapsearch with filter on server."""
     proc = await asyncio.create_subprocess_exec(
-        'ldapsearch',
-        '-vvv', '-x', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-        '-D', creds.un,
-        '-w', creds.pw,
-        '-b', 'dc=md,dc=test',
-        '(description=*desc)',
+        "ldapsearch",
+        "-vvv", "-x", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D", creds.un,
+        "-w", creds.pw,
+        "-b", "dc=md,dc=test",
+        "(description=*desc)",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE)
 
     raw_data, _ = await proc.communicate()
-    data = raw_data.decode().split('\n')
+    data = raw_data.decode().split("\n")
     result = await proc.wait()
 
     assert result == 0
@@ -104,7 +104,7 @@ async def test_ldap_search_filter_prefix(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_bind_policy(
     session: AsyncSession,
     settings: Settings,
@@ -112,32 +112,32 @@ async def test_bind_policy(
     ldap_session: LDAPSession,
 ) -> None:
     """Bind with policy."""
-    policy = await ldap_session._get_policy(IPv4Address('127.0.0.1'), session)
+    policy = await ldap_session._get_policy(IPv4Address("127.0.0.1"), session)
     assert policy
 
     group_dir = await get_group(
-        'cn=domain admins,cn=groups,dc=md,dc=test', session)
+        "cn=domain admins,cn=groups,dc=md,dc=test", session)
     policy.groups.append(group_dir.group)
     await session.commit()
 
     proc = await asyncio.create_subprocess_exec(
-        'ldapsearch',
-        '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-        '-D', creds.un, '-x', '-w', creds.pw)
+        "ldapsearch",
+        "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D", creds.un, "-x", "-w", creds.pw)
 
     result = await proc.wait()
     assert result == 0
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_bind_policy_missing_group(
         session: AsyncSession,
         ldap_session: LDAPSession,
         settings: Settings,
         creds: TestCreds) -> None:
     """Bind policy fail."""
-    policy = await ldap_session._get_policy(IPv4Address('127.0.0.1'), session)
+    policy = await ldap_session._get_policy(IPv4Address("127.0.0.1"), session)
 
     assert policy
 
@@ -146,7 +146,7 @@ async def test_bind_policy_missing_group(
         .options(selectinload(User.groups)))).one()
 
     policy.groups = await get_groups(
-        ['cn=domain admins,cn=groups,dc=md,dc=test'],
+        ["cn=domain admins,cn=groups,dc=md,dc=test"],
         session,
     )
     user.groups.clear()
@@ -155,24 +155,24 @@ async def test_bind_policy_missing_group(
     assert not await is_user_group_valid(user, policy, session)
 
     proc = await asyncio.create_subprocess_exec(
-        'ldapsearch',
-        '-vvv', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-        '-D', creds.un, '-x', '-w', creds.pw)
+        "ldapsearch",
+        "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D", creds.un, "-x", "-w", creds.pw)
 
     result = await proc.wait()
     assert result == 49
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_ldap_bind(settings: Settings, creds: TestCreds) -> None:
     """Test ldapsearch on server."""
     proc = await asyncio.create_subprocess_exec(
-        'ldapsearch',
-        '-vvv', '-x', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-        '-D', creds.un,
-        '-w', creds.pw,
+        "ldapsearch",
+        "-vvv", "-x", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D", creds.un,
+        "-w", creds.pw,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE)
 
@@ -181,8 +181,8 @@ async def test_ldap_bind(settings: Settings, creds: TestCreds) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_bvalue_in_search_request(
     session: AsyncSession,
     ldap_bound_session: LDAPSession,
@@ -206,13 +206,13 @@ async def test_bvalue_in_search_request(
     assert result
 
     for attr in result.partial_attributes:
-        if attr.type == 'attr_with_bvalue':
+        if attr.type == "attr_with_bvalue":
             assert isinstance(attr.vals[0], bytes)
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
-@pytest.mark.usefixtures('session')
+@pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("session")
 async def test_ldap_search_access_control_denied(
     settings: Settings,
     creds: TestCreds,
@@ -223,19 +223,19 @@ async def test_ldap_search_access_control_denied(
     Default user can read himself and parent containers.
     """
     proc = await asyncio.create_subprocess_exec(
-        'ldapsearch',
-        '-vvv', '-x', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-        '-D', 'user_non_admin',
-        '-w', creds.pw,
-        '-b', 'dc=md,dc=test', 'objectclass=*',
+        "ldapsearch",
+        "-vvv", "-x", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D", "user_non_admin",
+        "-w", creds.pw,
+        "-b", "dc=md,dc=test", "objectclass=*",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE)
 
     raw_data, _ = await proc.communicate()
-    data = raw_data.decode().split('\n')
+    data = raw_data.decode().split("\n")
     result = await proc.wait()
 
-    dn_list = [d for d in data if d.startswith('dn:')]
+    dn_list = [d for d in data if d.startswith("dn:")]
 
     assert result == 0
     assert dn_list == [
@@ -245,7 +245,7 @@ async def test_ldap_search_access_control_denied(
     ]
 
     await create_access_policy(
-        name='Groups Read Access Policy',
+        name="Groups Read Access Policy",
         can_add=False,
         can_modify=False,
         can_read=True,
@@ -257,27 +257,27 @@ async def test_ldap_search_access_control_denied(
     await session.commit()
 
     proc = await asyncio.create_subprocess_exec(
-        'ldapsearch',
-        '-vvv', '-x', '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-        '-D', 'user_non_admin',
-        '-w', creds.pw,
-        '-b', 'dc=md,dc=test', 'objectclass=*',
+        "ldapsearch",
+        "-vvv", "-x", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D", "user_non_admin",
+        "-w", creds.pw,
+        "-b", "dc=md,dc=test", "objectclass=*",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE)
 
     raw_data, _ = await proc.communicate()
-    data = raw_data.decode().split('\n')
+    data = raw_data.decode().split("\n")
     result = await proc.wait()
 
-    dn_list = [d for d in data if d.startswith('dn:')]
+    dn_list = [d for d in data if d.startswith("dn:")]
 
     assert result == 0
     assert sorted(dn_list) == sorted([
-        'dn: dc=md,dc=test',
-        'dn: ou=users,dc=md,dc=test',
-        'dn: cn=groups,dc=md,dc=test',
-        'dn: cn=domain admins,cn=groups,dc=md,dc=test',
-        'dn: cn=developers,cn=groups,dc=md,dc=test',
-        'dn: cn=domain users,cn=groups,dc=md,dc=test',
-        'dn: cn=user_non_admin,ou=users,dc=md,dc=test',
+        "dn: dc=md,dc=test",
+        "dn: ou=users,dc=md,dc=test",
+        "dn: cn=groups,dc=md,dc=test",
+        "dn: cn=domain admins,cn=groups,dc=md,dc=test",
+        "dn: cn=developers,cn=groups,dc=md,dc=test",
+        "dn: cn=domain users,cn=groups,dc=md,dc=test",
+        "dn: cn=user_non_admin,ou=users,dc=md,dc=test",
     ])

--- a/tests/test_ldap/test_util/test_search.py
+++ b/tests/test_ldap/test_util/test_search.py
@@ -31,12 +31,20 @@ async def test_ldap_search(settings: Settings, creds: TestCreds) -> None:
     """Test ldapsearch on server."""
     proc = await asyncio.create_subprocess_exec(
         "ldapsearch",
-        "-vvv", "-x", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-        "-D", creds.un,
-        "-w", creds.pw,
-        "-b", "dc=md,dc=test", "objectclass=*",
+        "-vvv",
+        "-x",
+        "-H",
+        f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D",
+        creds.un,
+        "-w",
+        creds.pw,
+        "-b",
+        "dc=md,dc=test",
+        "objectclass=*",
         stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE)
+        stderr=asyncio.subprocess.PIPE,
+    )
 
     raw_data, _ = await proc.communicate()
     data = raw_data.decode().split("\n")
@@ -52,22 +60,30 @@ async def test_ldap_search(settings: Settings, creds: TestCreds) -> None:
 @pytest.mark.usefixtures("setup_session")
 @pytest.mark.usefixtures("session")
 async def test_ldap_search_filter(
-    settings: Settings, creds: TestCreds,
+    settings: Settings,
+    creds: TestCreds,
 ) -> None:
     """Test ldapsearch with filter on server."""
     proc = await asyncio.create_subprocess_exec(
         "ldapsearch",
-        "-vvv", "-x", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-        "-D", creds.un,
-        "-w", creds.pw,
-        "-b", "dc=md,dc=test",
+        "-vvv",
+        "-x",
+        "-H",
+        f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D",
+        creds.un,
+        "-w",
+        creds.pw,
+        "-b",
+        "dc=md,dc=test",
         "(&"
         "(objectClass=user)"
         "(memberOf:1.2.840.113556.1.4.1941:=cn=domain admins,cn=groups,dc=md,\
             dc=test)"
         ")",
         stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE)
+        stderr=asyncio.subprocess.PIPE,
+    )
 
     raw_data, _ = await proc.communicate()
     data = raw_data.decode().split("\n")
@@ -82,18 +98,26 @@ async def test_ldap_search_filter(
 @pytest.mark.usefixtures("setup_session")
 @pytest.mark.usefixtures("session")
 async def test_ldap_search_filter_prefix(
-    settings: Settings, creds: TestCreds,
+    settings: Settings,
+    creds: TestCreds,
 ) -> None:
     """Test ldapsearch with filter on server."""
     proc = await asyncio.create_subprocess_exec(
         "ldapsearch",
-        "-vvv", "-x", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-        "-D", creds.un,
-        "-w", creds.pw,
-        "-b", "dc=md,dc=test",
+        "-vvv",
+        "-x",
+        "-H",
+        f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D",
+        creds.un,
+        "-w",
+        creds.pw,
+        "-b",
+        "dc=md,dc=test",
         "(description=*desc)",
         stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE)
+        stderr=asyncio.subprocess.PIPE,
+    )
 
     raw_data, _ = await proc.communicate()
     data = raw_data.decode().split("\n")
@@ -116,14 +140,22 @@ async def test_bind_policy(
     assert policy
 
     group_dir = await get_group(
-        "cn=domain admins,cn=groups,dc=md,dc=test", session)
+        "cn=domain admins,cn=groups,dc=md,dc=test", session
+    )
     policy.groups.append(group_dir.group)
     await session.commit()
 
     proc = await asyncio.create_subprocess_exec(
         "ldapsearch",
-        "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-        "-D", creds.un, "-x", "-w", creds.pw)
+        "-vvv",
+        "-H",
+        f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D",
+        creds.un,
+        "-x",
+        "-w",
+        creds.pw,
+    )
 
     result = await proc.wait()
     assert result == 0
@@ -132,18 +164,23 @@ async def test_bind_policy(
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("setup_session")
 async def test_bind_policy_missing_group(
-        session: AsyncSession,
-        ldap_session: LDAPSession,
-        settings: Settings,
-        creds: TestCreds) -> None:
+    session: AsyncSession,
+    ldap_session: LDAPSession,
+    settings: Settings,
+    creds: TestCreds,
+) -> None:
     """Bind policy fail."""
     policy = await ldap_session._get_policy(IPv4Address("127.0.0.1"), session)
 
     assert policy
 
-    user = (await session.scalars(
-        select(User).filter_by(display_name="user0")
-        .options(selectinload(User.groups)))).one()
+    user = (
+        await session.scalars(
+            select(User)
+            .filter_by(display_name="user0")
+            .options(selectinload(User.groups))
+        )
+    ).one()
 
     policy.groups = await get_groups(
         ["cn=domain admins,cn=groups,dc=md,dc=test"],
@@ -156,8 +193,15 @@ async def test_bind_policy_missing_group(
 
     proc = await asyncio.create_subprocess_exec(
         "ldapsearch",
-        "-vvv", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-        "-D", creds.un, "-x", "-w", creds.pw)
+        "-vvv",
+        "-H",
+        f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D",
+        creds.un,
+        "-x",
+        "-w",
+        creds.pw,
+    )
 
     result = await proc.wait()
     assert result == 49
@@ -170,11 +214,17 @@ async def test_ldap_bind(settings: Settings, creds: TestCreds) -> None:
     """Test ldapsearch on server."""
     proc = await asyncio.create_subprocess_exec(
         "ldapsearch",
-        "-vvv", "-x", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-        "-D", creds.un,
-        "-w", creds.pw,
+        "-vvv",
+        "-x",
+        "-H",
+        f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D",
+        creds.un,
+        "-w",
+        creds.pw,
         stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE)
+        stderr=asyncio.subprocess.PIPE,
+    )
 
     result = await proc.wait()
     assert result == 0
@@ -200,8 +250,9 @@ async def test_bvalue_in_search_request(
         attributes=["*"],
     )
 
-    result: SearchResultEntry = await anext(request.handle(
-        session, ldap_bound_session, settings))  # type: ignore
+    result: SearchResultEntry = await anext(
+        request.handle(session, ldap_bound_session, settings)
+    )  # type: ignore
 
     assert result
 
@@ -224,12 +275,20 @@ async def test_ldap_search_access_control_denied(
     """
     proc = await asyncio.create_subprocess_exec(
         "ldapsearch",
-        "-vvv", "-x", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-        "-D", "user_non_admin",
-        "-w", creds.pw,
-        "-b", "dc=md,dc=test", "objectclass=*",
+        "-vvv",
+        "-x",
+        "-H",
+        f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D",
+        "user_non_admin",
+        "-w",
+        creds.pw,
+        "-b",
+        "dc=md,dc=test",
+        "objectclass=*",
         stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE)
+        stderr=asyncio.subprocess.PIPE,
+    )
 
     raw_data, _ = await proc.communicate()
     data = raw_data.decode().split("\n")
@@ -258,12 +317,20 @@ async def test_ldap_search_access_control_denied(
 
     proc = await asyncio.create_subprocess_exec(
         "ldapsearch",
-        "-vvv", "-x", "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-        "-D", "user_non_admin",
-        "-w", creds.pw,
-        "-b", "dc=md,dc=test", "objectclass=*",
+        "-vvv",
+        "-x",
+        "-H",
+        f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D",
+        "user_non_admin",
+        "-w",
+        creds.pw,
+        "-b",
+        "dc=md,dc=test",
+        "objectclass=*",
         stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE)
+        stderr=asyncio.subprocess.PIPE,
+    )
 
     raw_data, _ = await proc.communicate()
     data = raw_data.decode().split("\n")
@@ -272,12 +339,14 @@ async def test_ldap_search_access_control_denied(
     dn_list = [d for d in data if d.startswith("dn:")]
 
     assert result == 0
-    assert sorted(dn_list) == sorted([
-        "dn: dc=md,dc=test",
-        "dn: ou=users,dc=md,dc=test",
-        "dn: cn=groups,dc=md,dc=test",
-        "dn: cn=domain admins,cn=groups,dc=md,dc=test",
-        "dn: cn=developers,cn=groups,dc=md,dc=test",
-        "dn: cn=domain users,cn=groups,dc=md,dc=test",
-        "dn: cn=user_non_admin,ou=users,dc=md,dc=test",
-    ])
+    assert sorted(dn_list) == sorted(
+        [
+            "dn: dc=md,dc=test",
+            "dn: ou=users,dc=md,dc=test",
+            "dn: cn=groups,dc=md,dc=test",
+            "dn: cn=domain admins,cn=groups,dc=md,dc=test",
+            "dn: cn=developers,cn=groups,dc=md,dc=test",
+            "dn: cn=domain users,cn=groups,dc=md,dc=test",
+            "dn: cn=user_non_admin,ou=users,dc=md,dc=test",
+        ]
+    )

--- a/tests/test_ldap/test_util/test_whoami.py
+++ b/tests/test_ldap/test_util/test_whoami.py
@@ -17,7 +17,8 @@ from tests.conftest import TestCreds
 async def test_anonymous_whoami(settings: Settings) -> None:
     """Test anonymous whoami."""
     proc = await asyncio.create_subprocess_exec(
-        "ldapwhoami", "-x", "-H", f"ldap://{settings.HOST}:{settings.PORT}")
+        "ldapwhoami", "-x", "-H", f"ldap://{settings.HOST}:{settings.PORT}"
+    )
 
     assert await proc.wait() == 0
 
@@ -27,10 +28,14 @@ async def test_anonymous_whoami(settings: Settings) -> None:
 async def test_binded_whoami(settings: Settings, creds: TestCreds) -> None:
     """Test anonymous whoami."""
     proc = await asyncio.create_subprocess_exec(
-        "ldapwhoami", "-x",
-        "-H", f"ldap://{settings.HOST}:{settings.PORT}",
-        "-D", creds.un,
-        "-w", creds.pw,
+        "ldapwhoami",
+        "-x",
+        "-H",
+        f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D",
+        creds.un,
+        "-w",
+        creds.pw,
     )
 
     assert await proc.wait() == 0

--- a/tests/test_ldap/test_util/test_whoami.py
+++ b/tests/test_ldap/test_util/test_whoami.py
@@ -13,24 +13,24 @@ from tests.conftest import TestCreds
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_anonymous_whoami(settings: Settings) -> None:
     """Test anonymous whoami."""
     proc = await asyncio.create_subprocess_exec(
-        'ldapwhoami', '-x', '-H', f'ldap://{settings.HOST}:{settings.PORT}')
+        "ldapwhoami", "-x", "-H", f"ldap://{settings.HOST}:{settings.PORT}")
 
     assert await proc.wait() == 0
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures('setup_session')
+@pytest.mark.usefixtures("setup_session")
 async def test_binded_whoami(settings: Settings, creds: TestCreds) -> None:
     """Test anonymous whoami."""
     proc = await asyncio.create_subprocess_exec(
-        'ldapwhoami', '-x',
-        '-H', f'ldap://{settings.HOST}:{settings.PORT}',
-        '-D', creds.un,
-        '-w', creds.pw,
+        "ldapwhoami", "-x",
+        "-H", f"ldap://{settings.HOST}:{settings.PORT}",
+        "-D", creds.un,
+        "-w", creds.pw,
     )
 
     assert await proc.wait() == 0


### PR DESCRIPTION
note: возможно стоит форматнуть сначала с настройкой skip trailling comma true и руками поправить то, что не нравится, чем форматнуть с настройкой skip trailling comma false и руками править, при первом варианте как будто бы меньше правок, т.к. при втором варианте все аргументы разворачиваются в несколько строк, т.к. раньше у нас везде стояла закрывающая запятая
[ DONE ]

note2: нужно проверить что все предыдущие настройки flake8 успешно интерпретированы в ruff, т.к. инфа была собрана по всем и проверены все, но рельзультат тестов работы зафиксирован только по нескольким правилам flake8
[ DONE ]

upd3. надо разобраться и правильно разрешить конфликты текущих flake8, mypy и isort, и только затем выпиливать их. На начальном этапе могут служить валидацией движения по правильному пути репрезентации прошлых  правил.
[ DONE ]