### PR TITLE
Dns bugs fix task 671

### DIFF
--- a/.dns/dns_api.py
+++ b/.dns/dns_api.py
@@ -244,27 +244,23 @@ class BindDNSServerManager:
         self.reload(zone_name)
 
     def _check_config(self, config: str) -> str | None:
-        with tempfile.NamedTemporaryFile(mode="w", delete=False) as tf:
+        with tempfile.NamedTemporaryFile(mode="w") as tf:
             tf.write(config)
             tmp_path = tf.name
 
-        try:
             result = subprocess.run(  # noqa: S603
                 ["/usr/bin/named-checkconf", tmp_path],
                 capture_output=True,
                 text=True,
             )
+
             return result.stderr
-        finally:
-            with contextlib.suppress(FileNotFoundError):
-                os.remove(tmp_path)
 
     def _check_zone(self, zonefile: str, zone_name: str) -> str | None:
-        with tempfile.NamedTemporaryFile(mode="w", delete=False) as zf:
+        with tempfile.NamedTemporaryFile(mode="w") as zf:
             zf.write(zonefile)
             tmp_path = zf.name
 
-        try:
             result = subprocess.run(  # noqa: S603
                 [
                     "/usr/bin/named-checkzone",
@@ -276,10 +272,8 @@ class BindDNSServerManager:
                 capture_output=True,
                 text=True,
             )
+
             return result.stderr
-        finally:
-            with contextlib.suppress(FileNotFoundError):
-                os.remove(tmp_path)
 
     def _get_base_domain(self) -> str:
         """Get base domain.

--- a/.dns/dns_api.py
+++ b/.dns/dns_api.py
@@ -667,7 +667,7 @@ class BindDNSServerManager:
             self.add_record(
                 DNSRecord(
                     name=record.get("name") + zone_name,
-                    value=record.get("value") + zone_name,
+                    value=record.get("value") + zone_name + ".",
                     ttl=604800,
                 ),
                 record.get("type"),

--- a/.dns/dns_api.py
+++ b/.dns/dns_api.py
@@ -31,6 +31,7 @@ TEMPLATES: ClassVar[jinja2.Environment] = jinja2.Environment(
 ZONE_FILES_DIR = "/opt"
 NAMED_LOCAL = "/etc/bind/named.conf.local"
 NAMED_OPTIONS = "/etc/bind/named.conf.options"
+BIND_LOG_FILE_PATH = "/var/log/named/bind.log"
 
 FIRST_SETUP_RECORDS = [
     {"name": "_ldap._tcp.", "value": "0 0 389 ", "type": "SRV"},
@@ -251,7 +252,7 @@ class BindDNSServerManager:
             4. If found, return the error message; otherwise, return None.
 
         """
-        with open("/var/log/named/bind.log") as file:
+        with open(BIND_LOG_FILE_PATH) as file:
             log = file.readlines()
 
         recent_errors = log[-10:]

--- a/.dns/dns_api.py
+++ b/.dns/dns_api.py
@@ -730,8 +730,8 @@ class BindDNSServerManager:
         for record in FIRST_SETUP_RECORDS:
             self.add_record(
                 DNSRecord(
-                    name=record.get("name") + zone_name,
-                    value=record.get("value") + zone_name + ".",
+                    name=f"{record.get("name")}{zone_name}",
+                    value=f"{record.get("value")}{zone_name}.",
                     ttl=604800,
                 ),
                 record.get("type"),

--- a/.dns/dns_api.py
+++ b/.dns/dns_api.py
@@ -270,7 +270,7 @@ class BindDNSServerManager:
                 ):
                     continue
 
-                return row.split(" ")[2:]
+                return " ".join(row.split(" ")[2:])
 
         return None
 

--- a/.dns/dns_api.py
+++ b/.dns/dns_api.py
@@ -33,7 +33,6 @@ ZONE_FILES_DIR = "/opt"
 NAMED_CONF = "/etc/bind/named.conf"
 NAMED_LOCAL = "/etc/bind/named.conf.local"
 NAMED_OPTIONS = "/etc/bind/named.conf.options"
-BIND_LOG_FILE_PATH = "/var/log/named/bind.log"
 
 FIRST_SETUP_RECORDS = [
     {"name": "_ldap._tcp.", "value": "0 0 389 ", "type": "SRV"},

--- a/.dns/dns_api.py
+++ b/.dns/dns_api.py
@@ -1221,7 +1221,7 @@ def create_record(
 
 
 @record_router.patch("")
-async def update_record(
+def update_record(
     data: DNSRecordUpdateRequest,
     dns_manager: Annotated[BindDNSServerManager, Depends(get_dns_manager)],
 ) -> None:

--- a/.docker/bind9.Dockerfile
+++ b/.docker/bind9.Dockerfile
@@ -34,6 +34,12 @@ WORKDIR /server
 
 RUN chown bind:bind /opt
 
+RUN mkdir /var/log/named && \
+    touch /var/log/named/bind.log && \
+    chown bind:bind /var/log/named && \
+    chmod 755 /var/log/named  && \
+    chmod 644 /var/log/named/bind.log
+
 EXPOSE 8000
 
 ENTRYPOINT [ "./entrypoint.sh" ]

--- a/.package/docker-compose.yml
+++ b/.package/docker-compose.yml
@@ -138,7 +138,7 @@ services:
       - dns_server_file:/DNS_server_file/
       - dns_server_config:/DNS_server_configs/
       - ldap_keytab:/LDAP_keytab/
-      - ./resolv.conf:/etc/resolv.conf
+      - ./resolv.conf:/resolv.conf
     hostname: api_server
     environment:
       USE_CORE_TLS: 1

--- a/.package/docker-compose.yml
+++ b/.package/docker-compose.yml
@@ -138,6 +138,7 @@ services:
       - dns_server_file:/DNS_server_file/
       - dns_server_config:/DNS_server_configs/
       - ldap_keytab:/LDAP_keytab/
+      - ./resolv.conf:/etc/resolv.conf
     hostname: api_server
     environment:
       USE_CORE_TLS: 1

--- a/.package/docker-compose.yml
+++ b/.package/docker-compose.yml
@@ -305,6 +305,8 @@ services:
     tty: true
     env_file:
       - .env
+    environment:
+      - USE_CONFIG_FILE_LOGGING=true
     depends_on:
       ldap_server:
         condition: service_healthy

--- a/.package/setup.bat
+++ b/.package/setup.bat
@@ -12,6 +12,7 @@ set "output_file=resolv.conf"
 
 if exist "%output_file%" del "%output_file%"
 
+::: Extract DNS server IPs from Windows ipconfig and write them to resolv.conf
 for /f "tokens=2 delims=:" %%a in ('ipconfig /all ^| findstr /i "DNS Servers"') do (
     set "dns=%%a"
     set "dns=!dns: =!"

--- a/.package/setup.bat
+++ b/.package/setup.bat
@@ -8,6 +8,19 @@ if not exist ".env" type nul > .env
 findstr /v /r /c:"^[^=]*=$" .env > .env.tmp
 move /y .env.tmp .env >nul
 
+set "output_file=resolv.conf"
+
+if exist "%output_file%" del "%output_file%"
+
+for /f "tokens=2 delims=:" %%a in ('ipconfig /all ^| findstr /i "DNS Servers"') do (
+    set "dns=%%a"
+    set "dns=!dns: =!"
+    echo !dns! | findstr /r "^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$" >nul
+    if !errorlevel! equ 0 (
+        echo nameserver !dns! >> "%output_file%"
+    )
+)
+
 :: ========== VARIABLE DEFINITION ==========
 
 :: 1. DEFAULT_NAMESERVER

--- a/.package/setup.sh
+++ b/.package/setup.sh
@@ -12,6 +12,8 @@ add_env_var() {
     echo "${var_name}=${var_value}" >> .env
 }
 
+cp /etc/resolv.conf resolv.conf
+
 # DEFAULT_NAMESERVER
 if ! get_env_var "DEFAULT_NAMESERVER"; then
     while true; do

--- a/app/api/exception_handlers.py
+++ b/app/api/exception_handlers.py
@@ -33,6 +33,15 @@ async def handle_dns_error(
     raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE)
 
 
+async def handle_dns_api_error(
+    request: Request,  # noqa: ARG001
+    exc: Exception,
+) -> NoReturn:
+    """Handle DNS API error."""
+    logger.critical("DNS API error: {}", exc)
+    raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+
 async def handle_instance_not_found_error(
     request: Request,  # noqa: ARG001
     exc: Exception,  # noqa: ARG001

--- a/app/api/main/dns_router.py
+++ b/app/api/main/dns_router.py
@@ -193,14 +193,10 @@ async def delete_zone(
 async def check_dns_forward_zone(
     data: DNSServiceForwardZoneCheckRequest,
     dns_manager: FromDishka[AbstractDNSManager],
-    settings: FromDishka[Settings],
 ) -> list[DNSForwardServerStatus]:
     """Check given DNS forward zone for availability."""
     return [
-        await dns_manager.check_forward_dns_server(
-            dns_server_ip,
-            settings.DNS_RESOLV_CONF_PATH,
-        )
+        await dns_manager.check_forward_dns_server(dns_server_ip)
         for dns_server_ip in data.dns_server_ips
     ]
 

--- a/app/api/main/dns_router.py
+++ b/app/api/main/dns_router.py
@@ -193,10 +193,14 @@ async def delete_zone(
 async def check_dns_forward_zone(
     data: DNSServiceForwardZoneCheckRequest,
     dns_manager: FromDishka[AbstractDNSManager],
+    settings: FromDishka[Settings],
 ) -> list[DNSForwardServerStatus]:
     """Check given DNS forward zone for availability."""
     return [
-        await dns_manager.check_forward_dns_server(dns_server_ip)
+        await dns_manager.check_forward_dns_server(
+            dns_server_ip,
+            settings.HOST_DNS_SERVERS,
+        )
         for dns_server_ip in data.dns_server_ips
     ]
 

--- a/app/api/main/dns_router.py
+++ b/app/api/main/dns_router.py
@@ -193,10 +193,14 @@ async def delete_zone(
 async def check_dns_forward_zone(
     data: DNSServiceForwardZoneCheckRequest,
     dns_manager: FromDishka[AbstractDNSManager],
+    settings: FromDishka[Settings],
 ) -> list[DNSForwardServerStatus]:
     """Check given DNS forward zone for availability."""
     return [
-        await dns_manager.check_forward_dns_server(dns_server_ip)
+        await dns_manager.check_forward_dns_server(
+            dns_server_ip,
+            settings.DNS_RESOLV_CONF_PATH,
+        )
         for dns_server_ip in data.dns_server_ips
     ]
 

--- a/app/config.py
+++ b/app/config.py
@@ -133,6 +133,7 @@ class Settings(BaseModel):
     DNS_REVERSE_ZONE_FILE: str = "/DNS_server_file/db.reverse.zone"
     DNS_SERVER_NAMED_CONF: str = "/DNS_server_configs/named.conf"
     DNS_SERVER_NAMED_CONF_LOCAL: str = "/DNS_server_configs/named.conf.local"
+    DNS_RESOLV_CONF_PATH: str = "/resolv.conf"
 
     ENABLE_SQLALCHEMY_LOGGING: bool = False
 

--- a/app/config.py
+++ b/app/config.py
@@ -187,3 +187,21 @@ class Settings(BaseModel):
     def from_os(cls) -> "Settings":
         """Get cls from environ."""
         return Settings(**os.environ)
+
+    @cached_property
+    def HOST_DNS_SERVERS(self) -> list[str]: # noqa: N802
+        """Get resolv.conf path."""
+        host_dns_servers: list[str] = []
+        if os.path.exists("/resolv.conf"):
+            with open("/resolv.conf") as resolv_file:
+                lines = resolv_file.readlines()
+
+                for line in lines:
+                    if line.startswith("nameserver"):
+                        parts = line.split()
+                        if len(parts) == 2:
+                            host_dns_servers.append(parts[1].strip())
+
+            return host_dns_servers
+
+        return ["1.1.1.1"]

--- a/app/config.py
+++ b/app/config.py
@@ -189,7 +189,7 @@ class Settings(BaseModel):
         return Settings(**os.environ)
 
     @cached_property
-    def HOST_DNS_SERVERS(self) -> list[str]: # noqa: N802
+    def HOST_DNS_SERVERS(self) -> list[str]:  # noqa: N802
         """Get resolv.conf path."""
         host_dns_servers: list[str] = []
         if os.path.exists("/resolv.conf"):

--- a/app/config.py
+++ b/app/config.py
@@ -133,7 +133,6 @@ class Settings(BaseModel):
     DNS_REVERSE_ZONE_FILE: str = "/DNS_server_file/db.reverse.zone"
     DNS_SERVER_NAMED_CONF: str = "/DNS_server_configs/named.conf"
     DNS_SERVER_NAMED_CONF_LOCAL: str = "/DNS_server_configs/named.conf.local"
-    DNS_RESOLV_CONF_PATH: str = "/resolv.conf"
 
     ENABLE_SQLALCHEMY_LOGGING: bool = False
 

--- a/app/extra/resolv.conf
+++ b/app/extra/resolv.conf
@@ -1,0 +1,1 @@
+nameserver 1.1.1.1

--- a/app/extra/resolv.conf
+++ b/app/extra/resolv.conf
@@ -1,1 +1,0 @@
-nameserver 1.1.1.1

--- a/app/ldap_protocol/dns/__init__.py
+++ b/app/ldap_protocol/dns/__init__.py
@@ -6,6 +6,7 @@ from .base import (
     DNS_MANAGER_ZONE_NAME,
     AbstractDNSManager,
     DNSConnectionError,
+    DNSError,
     DNSForwardServerStatus,
     DNSForwardZone,
     DNSManagerSettings,
@@ -67,4 +68,5 @@ __all__ = [
     "DNS_MANAGER_ZONE_NAME",
     "DNS_MANAGER_STATE_NAME",
     "DNSNotImplementedError",
+    "DNSError",
 ]

--- a/app/ldap_protocol/dns/base.py
+++ b/app/ldap_protocol/dns/base.py
@@ -49,6 +49,9 @@ class DNSForwarderServerStatus(StrEnum):
 class DNSConnectionError(ConnectionError):
     """API Error."""
 
+class DNSError(Exception):
+    """DNS Error."""
+
 
 class DNSNotImplementedError(NotImplementedError):
     """API Not Implemented Error."""

--- a/app/ldap_protocol/dns/base.py
+++ b/app/ldap_protocol/dns/base.py
@@ -311,7 +311,6 @@ class AbstractDNSManager(ABC):
     async def check_forward_dns_server(
         self,
         dns_server_ip: IPv4Address | IPv6Address,
-        resolv_conf_path: str,
     ) -> DNSForwardServerStatus:
         raise DNSNotImplementedError
 

--- a/app/ldap_protocol/dns/base.py
+++ b/app/ldap_protocol/dns/base.py
@@ -49,6 +49,7 @@ class DNSForwarderServerStatus(StrEnum):
 class DNSConnectionError(ConnectionError):
     """API Error."""
 
+
 class DNSError(Exception):
     """DNS Error."""
 

--- a/app/ldap_protocol/dns/base.py
+++ b/app/ldap_protocol/dns/base.py
@@ -311,6 +311,7 @@ class AbstractDNSManager(ABC):
     async def check_forward_dns_server(
         self,
         dns_server_ip: IPv4Address | IPv6Address,
+        resolv_conf_path: str,
     ) -> DNSForwardServerStatus:
         raise DNSNotImplementedError
 

--- a/app/ldap_protocol/dns/base.py
+++ b/app/ldap_protocol/dns/base.py
@@ -311,6 +311,7 @@ class AbstractDNSManager(ABC):
     async def check_forward_dns_server(
         self,
         dns_server_ip: IPv4Address | IPv6Address,
+        host_dns_servers: list[str],
     ) -> DNSForwardServerStatus:
         raise DNSNotImplementedError
 

--- a/app/ldap_protocol/dns/selfhosted.py
+++ b/app/ldap_protocol/dns/selfhosted.py
@@ -26,7 +26,7 @@ from .base import (
 )
 from .utils import logger_wraps
 
-RESOLV_CONF_PATH = "/etc/resolv.conf"
+RESOLV_CONF_PATH = "/resolv.conf"
 
 
 class SelfHostedDNSManager(AbstractDNSManager):

--- a/app/ldap_protocol/dns/selfhosted.py
+++ b/app/ldap_protocol/dns/selfhosted.py
@@ -26,8 +26,6 @@ from .base import (
 )
 from .utils import logger_wraps
 
-RESOLV_CONF_PATH = "/resolv.conf"
-
 
 class SelfHostedDNSManager(AbstractDNSManager):
     """Manager for selfhosted Bind9 DNS server."""
@@ -181,10 +179,10 @@ class SelfHostedDNSManager(AbstractDNSManager):
             if response.status_code != 200:
                 raise DNSError(response.text)
 
-    def get_dns_servers(self) -> list[str]:
+    def get_dns_servers(self, resolv_conf_path: str) -> list[str]:
         """Get list of DNS servers."""
         dns_servers = []
-        with open(RESOLV_CONF_PATH) as resolv_file:
+        with open(resolv_conf_path) as resolv_file:
             lines = resolv_file.readlines()
 
         for line in lines:
@@ -236,9 +234,10 @@ class SelfHostedDNSManager(AbstractDNSManager):
     async def check_forward_dns_server(
         self,
         dns_server_ip: IPv4Address | IPv6Address,
+        resolv_conf_path: str,
     ) -> DNSForwardServerStatus:
         str_dns_server_ip = str(dns_server_ip)
-        dns_servers = self.get_dns_servers()
+        dns_servers = self.get_dns_servers(resolv_conf_path)
         log.info(f"{dns_servers}")
 
         if not dns_servers:

--- a/app/ldap_protocol/dns/selfhosted.py
+++ b/app/ldap_protocol/dns/selfhosted.py
@@ -5,6 +5,7 @@ License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
 
 import asyncio
+import os
 from dataclasses import asdict
 from ipaddress import IPv4Address, IPv6Address
 
@@ -26,14 +27,15 @@ from .base import (
 from .utils import logger_wraps
 
 HOST_DNS_SERVERS: list[str] = []
-with open("/resolv.conf") as resolv_file:
-    lines = resolv_file.readlines()
+if os.path.exists("/resolv.conf"):
+    with open("/resolv.conf") as resolv_file:
+        lines = resolv_file.readlines()
 
-    for line in lines:
-        if line.startswith("nameserver"):
-            parts = line.split()
-            if len(parts) == 2:
-                HOST_DNS_SERVERS.append(parts[1].strip())
+        for line in lines:
+            if line.startswith("nameserver"):
+                parts = line.split()
+                if len(parts) == 2:
+                    HOST_DNS_SERVERS.append(parts[1].strip())
 
 
 class SelfHostedDNSManager(AbstractDNSManager):

--- a/app/ldap_protocol/dns/selfhosted.py
+++ b/app/ldap_protocol/dns/selfhosted.py
@@ -221,7 +221,7 @@ class SelfHostedDNSManager(AbstractDNSManager):
                 latency = event_loop.time() - start_time
 
                 return (latency, fqdn[0].to_text())
-            except Exception:
+            except dns.resolver.NoAnswer:
                 return (float("inf"), None)
 
         fqdn_list = await asyncio.gather(

--- a/app/ldap_protocol/dns/selfhosted.py
+++ b/app/ldap_protocol/dns/selfhosted.py
@@ -22,7 +22,6 @@ from .base import (
     DNSZone,
     DNSZoneParam,
     DNSZoneType,
-    log,
 )
 from .utils import logger_wraps
 

--- a/app/ldap_protocol/dns/selfhosted.py
+++ b/app/ldap_protocol/dns/selfhosted.py
@@ -26,6 +26,8 @@ from .base import (
 )
 from .utils import logger_wraps
 
+RESOLV_CONF_PATH = "/etc/resolv.conf"
+
 
 class SelfHostedDNSManager(AbstractDNSManager):
     """Manager for selfhosted Bind9 DNS server."""
@@ -182,7 +184,7 @@ class SelfHostedDNSManager(AbstractDNSManager):
     def get_dns_servers(self) -> list[str]:
         """Get list of DNS servers."""
         dns_servers = []
-        with open("/etc/resolv.conf") as resolv_file:
+        with open(RESOLV_CONF_PATH) as resolv_file:
             lines = resolv_file.readlines()
 
         for line in lines:
@@ -212,7 +214,7 @@ class SelfHostedDNSManager(AbstractDNSManager):
             resolver.nameservers = [server]
 
             try:
-                event_loop = asyncio.get_event_loop()
+                event_loop = asyncio.get_running_loop()
                 start_time = event_loop.time()
                 fqdn = resolver.resolve(
                     reversed_ip,

--- a/app/multidirectory.py
+++ b/app/multidirectory.py
@@ -37,6 +37,7 @@ from api import (
 )
 from api.exception_handlers import (
     handle_db_connect_error,
+    handle_dns_api_error,
     handle_dns_error,
     handle_instance_cant_modify_error,
     handle_instance_not_found_error,
@@ -53,7 +54,11 @@ from ioc import (
     MFAProvider,
 )
 from ldap_protocol.dependency import resolve_deps
-from ldap_protocol.dns import DNSConnectionError, DNSNotImplementedError
+from ldap_protocol.dns import (
+    DNSConnectionError,
+    DNSError,
+    DNSNotImplementedError,
+)
 from ldap_protocol.exceptions import (
     InstanceCantModifyError,
     InstanceNotFoundError,
@@ -122,6 +127,7 @@ def _create_basic_app(settings: Settings) -> FastAPI:
     app.add_exception_handler(sa_exc.InterfaceError, handle_db_connect_error)
     app.add_exception_handler(DNSException, handle_dns_error)
     app.add_exception_handler(DNSConnectionError, handle_dns_error)
+    app.add_exception_handler(DNSError, handle_dns_api_error)
     app.add_exception_handler(
         InstanceNotFoundError,
         handle_instance_not_found_error,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -237,6 +237,7 @@ services:
     restart: unless-stopped
     environment:
       - DEFAULT_NAMESERVER=127.0.0.2
+      - USE_CONFIG_FILE_LOGGING=true
     volumes:
       - dns_server_file:/opt/
       - dns_server_config:/etc/bind/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,6 @@ services:
       - dns_server_file:/DNS_server_file/
       - dns_server_config:/DNS_server_configs/
       - ldap_keytab:/LDAP_keytab/
-      - ./app/extra/resolv.conf:/resolv.conf
     env_file:
       local.env
     command: python multidirectory.py --http

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,7 @@ services:
       - dns_server_file:/DNS_server_file/
       - dns_server_config:/DNS_server_configs/
       - ldap_keytab:/LDAP_keytab/
+      - ./resolv.conf:/etc/resolv.conf
     env_file:
       local.env
     command: python multidirectory.py --http

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       - dns_server_file:/DNS_server_file/
       - dns_server_config:/DNS_server_configs/
       - ldap_keytab:/LDAP_keytab/
-      - ./resolv.conf:/resolv.conf
+      - ./app/extra/resolv.conf:/resolv.conf
     env_file:
       local.env
     command: python multidirectory.py --http

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       - dns_server_file:/DNS_server_file/
       - dns_server_config:/DNS_server_configs/
       - ldap_keytab:/LDAP_keytab/
-      - ./resolv.conf:/etc/resolv.conf
+      - ./resolv.conf:/resolv.conf
     env_file:
       local.env
     command: python multidirectory.py --http


### PR DESCRIPTION
1. Исправлен баг с дублированием домена в SRV-записях. Добавлена точка при добавлении записей при первичной настройке.
2. Переделана проверка forward зон. Теперь при установке через скрипт копируются DNS-сервера хоста и записываются в resolv.conf, после чего он маунтится в контейнер. При проверке DNS сервера и поиске FQDN проверяются все DNS-сервера хоста, и при нахождении возвращается ответ с наименьшей задержкой.
3. Добавлена обработка ошибок на стороне API DNS-сервера. Логи DNS-сервера теперь пишутся в файл. После перезагрузки зон или реконфига сервера читаются последние 10 строк лога и ищется ошибка, которая возникла не позднее 5 секунд после запроса. Если ошибка найдена, то возвращается ответ со статусом 400 и текстом ошибки.