### PR TITLE
Fix delete krbprincipalexpiration attribute 735

### DIFF
--- a/app/ldap_protocol/kerberos/utils.py
+++ b/app/ldap_protocol/kerberos/utils.py
@@ -99,7 +99,7 @@ async def unlock_principal(name: str, session: AsyncSession) -> None:
         .outerjoin(Directory.entity_type)
         .where(
             Directory.name.ilike(name),
-            EntityType.name == "User",
+            EntityType.name == "KRB Principal",
         )
         .scalar_subquery()
     )


### PR DESCRIPTION
### Задача

При разблокировке пользователя не удаляется атрибут `krbprincipalexpiration` у его принципала.

### Решение

В функции `unlock_principal` исправлен тип сущности.