### PR TITLE
Fix update policy_type parameter in network policy functions

### DIFF
--- a/app/ldap_protocol/identity/identity_manager.py
+++ b/app/ldap_protocol/identity/identity_manager.py
@@ -163,6 +163,7 @@ class IdentityManager(AbstractService):
             ip,
             user,
             self._session,
+            policy_type="is_http",
         )
         if network_policy is None:
             raise LoginFailedError("User not part of network policy")

--- a/app/ldap_protocol/identity/mfa_manager.py
+++ b/app/ldap_protocol/identity/mfa_manager.py
@@ -327,6 +327,7 @@ class MFAManager(AbstractService):
             ip,
             user,
             self._session,
+            policy_type="is_kerberos",
         )
 
         if network_policy is None or not network_policy.is_kerberos:

--- a/app/ldap_protocol/policies/network_policy.py
+++ b/app/ldap_protocol/policies/network_policy.py
@@ -81,6 +81,7 @@ async def get_user_network_policy(
     ip: IPv4Address | IPv6Address,
     user: User,
     session: AsyncSession,
+    policy_type: Literal["is_http", "is_ldap", "is_kerberos"],
 ) -> NetworkPolicy | None:
     """Get the highest priority network policy for user, ip and protocol.
 
@@ -90,7 +91,7 @@ async def get_user_network_policy(
     """
     user_group_ids = [group.id for group in user.groups]
 
-    query = build_policy_query(ip, "is_http", user_group_ids)
+    query = build_policy_query(ip, policy_type, user_group_ids)
 
     return await session.scalar(query)
 


### PR DESCRIPTION
This pull request updates how network policies are selected based on protocol type in the authentication and MFA flows. The main change is that the `get_user_network_policy` function now requires a `policy_type` argument, allowing callers to specify the protocol (such as HTTP or Kerberos) when retrieving the appropriate network policy. This improves the accuracy and flexibility of policy enforcement.

**Network policy protocol selection improvements:**

* Updated `get_user_network_policy` in `network_policy.py` to require a `policy_type` argument, allowing protocol-specific policy lookups.
* Modified the policy query in `get_user_network_policy` to use the provided `policy_type` instead of hardcoding "is_http".

**Authentication and MFA flow updates:**

* In `identity_manager.py`'s `login` method, now passes `policy_type="is_http"` to `get_user_network_policy` to ensure HTTP policies are checked during login.
* In `mfa_manager.py`'s `proxy_request` method, now passes `policy_type="is_kerberos"` to `get_user_network_policy` to ensure Kerberos policies are checked during Kerberos proxy requests.