### PR TITLE
fix list id on schema models

### DIFF
--- a/app/api/ldap_schema/adapters/attribute_type.py
+++ b/app/api/ldap_schema/adapters/attribute_type.py
@@ -49,7 +49,7 @@ def _convert_update_uschema_to_dto(
 
 
 _convert_schema_to_dto = get_converter(
-    AttributeTypeSchema,
+    AttributeTypeSchema[None],
     AttributeTypeDTO[None],
     recipe=[
         allow_unlinked_optional(P[AttributeTypeDTO].id),
@@ -70,7 +70,7 @@ _convert_schema_to_dto = get_converter(
 
 _convert_dto_to_schema = get_converter(
     AttributeTypeDTO[int],
-    AttributeTypeSchema,
+    AttributeTypeSchema[int],
 )
 
 

--- a/app/api/ldap_schema/adapters/entity_type.py
+++ b/app/api/ldap_schema/adapters/entity_type.py
@@ -4,8 +4,7 @@ Copyright (c) 2024 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
 
-from adaptix import P
-from adaptix.conversion import allow_unlinked_optional, get_converter
+from adaptix.conversion import get_converter
 from fastapi import status
 
 from api.base_adapter import BaseAdapter
@@ -39,14 +38,13 @@ def _convert_update_chema_to_dto(
 
 
 _convert_request_to_dto = get_converter(
-    EntityTypeSchema,
+    EntityTypeSchema[None],
     EntityTypeDTO[None],
-    recipe=[allow_unlinked_optional(P[EntityTypeDTO].id)],
 )
 
 _convert_dto_to_schema = get_converter(
     EntityTypeDTO[int],
-    EntityTypeSchema,
+    EntityTypeSchema[int],
 )
 
 

--- a/app/api/ldap_schema/adapters/object_class.py
+++ b/app/api/ldap_schema/adapters/object_class.py
@@ -44,7 +44,7 @@ def _convert_update_schema_to_dto(
 
 
 _convert_schema_to_dto = get_converter(
-    ObjectClassSchema,
+    ObjectClassSchema[None],
     ObjectClassDTO[None, str],
     recipe=[
         link_function(
@@ -65,7 +65,7 @@ _convert_schema_to_dto = get_converter(
 
 _convert_dto_to_schema = get_converter(
     ObjectClassDTO[int, AttributeTypeDTO],
-    ObjectClassSchema,
+    ObjectClassSchema[int],
     recipe=[
         link_function(
             lambda dto: [attr.name for attr in dto.attribute_types_must],

--- a/app/api/ldap_schema/attribute_type_router.py
+++ b/app/api/ldap_schema/attribute_type_router.py
@@ -24,7 +24,7 @@ from ldap_protocol.utils.pagination import PaginationParams
     status_code=status.HTTP_201_CREATED,
 )
 async def create_one_attribute_type(
-    request_data: AttributeTypeSchema,
+    request_data: AttributeTypeSchema[None],
     adapter: FromDishka[AttributeTypeFastAPIAdapter],
 ) -> None:
     """Create a new Attribute Type."""
@@ -35,7 +35,7 @@ async def create_one_attribute_type(
 async def get_one_attribute_type(
     attribute_type_name: str,
     adapter: FromDishka[AttributeTypeFastAPIAdapter],
-) -> AttributeTypeSchema:
+) -> AttributeTypeSchema[int]:
     """Retrieve a one Attribute Type."""
     return await adapter.get(attribute_type_name)
 

--- a/app/api/ldap_schema/entity_type_router.py
+++ b/app/api/ldap_schema/entity_type_router.py
@@ -22,7 +22,7 @@ from ldap_protocol.utils.pagination import PaginationParams
 
 @ldap_schema_router.post("/entity_type", status_code=status.HTTP_201_CREATED)
 async def create_one_entity_type(
-    request_data: EntityTypeSchema,
+    request_data: EntityTypeSchema[None],
     adapter: FromDishka[LDAPEntityTypeFastAPIAdapter],
 ) -> None:
     """Create a new Entity Type."""
@@ -33,7 +33,7 @@ async def create_one_entity_type(
 async def get_one_entity_type(
     entity_type_name: str,
     adapter: FromDishka[LDAPEntityTypeFastAPIAdapter],
-) -> EntityTypeSchema:
+) -> EntityTypeSchema[int]:
     """Retrieve a one Entity Type."""
     return await adapter.get(entity_type_name)
 

--- a/app/api/ldap_schema/object_class_router.py
+++ b/app/api/ldap_schema/object_class_router.py
@@ -22,7 +22,7 @@ from ldap_protocol.utils.pagination import PaginationParams
 
 @ldap_schema_router.post("/object_class", status_code=status.HTTP_201_CREATED)
 async def create_one_object_class(
-    request_data: ObjectClassSchema,
+    request_data: ObjectClassSchema[None],
     adapter: FromDishka[ObjectClassFastAPIAdapter],
 ) -> None:
     """Create a new Object Class."""
@@ -33,7 +33,7 @@ async def create_one_object_class(
 async def get_one_object_class(
     object_class_name: str,
     adapter: FromDishka[ObjectClassFastAPIAdapter],
-) -> ObjectClassSchema:
+) -> ObjectClassSchema[int]:
     """Retrieve a one object class."""
     return await adapter.get(object_class_name)
 

--- a/app/api/ldap_schema/schema.py
+++ b/app/api/ldap_schema/schema.py
@@ -4,6 +4,8 @@ Copyright (c) 2025 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
 
+from typing import Generic, TypeVar
+
 from pydantic import BaseModel, Field
 
 from enums import KindType
@@ -13,11 +15,14 @@ from ldap_protocol.ldap_schema.constants import (
 )
 from ldap_protocol.utils.pagination import BasePaginationSchema
 
+_IdT = TypeVar("_IdT", int, None)
 
-class AttributeTypeSchema(BaseModel):
+
+class AttributeTypeSchema(BaseModel, Generic[_IdT]):
     """Attribute Type Schema."""
 
-    oid: str = Field(pattern=OID_REGEX_PATTERN)
+    id: _IdT = Field(default=None)  # type: ignore[assignment]
+    oid: str = Field(pattern=OID_REGEX_PATTERN, max_length=128)
     name: str = Field(min_length=1, max_length=255)
     syntax: str
     single_value: bool
@@ -39,10 +44,11 @@ class AttributeTypePaginationSchema(BasePaginationSchema[AttributeTypeSchema]):
     items: list[AttributeTypeSchema]
 
 
-class ObjectClassSchema(BaseModel):
+class ObjectClassSchema(BaseModel, Generic[_IdT]):
     """Object Class Request Schema."""
 
-    oid: str = Field(pattern=OID_REGEX_PATTERN)
+    id: _IdT = Field(default=None)  # type: ignore[assignment]
+    oid: str = Field(pattern=OID_REGEX_PATTERN, max_length=128)
     name: str = Field(min_length=1, max_length=255)
     superior_name: str | None
     kind: KindType
@@ -64,9 +70,10 @@ class ObjectClassUpdateSchema(BaseModel):
     attribute_type_names_may: list[str]
 
 
-class EntityTypeSchema(BaseModel):
+class EntityTypeSchema(BaseModel, Generic[_IdT]):
     """Entity Type Schema."""
 
+    id: _IdT = Field(default=None)  # type: ignore[assignment]
     name: str
     is_system: bool
     object_class_names: list[str] = Field(


### PR DESCRIPTION
This pull request introduces generic typing for the main schema classes used in the LDAP schema API, allowing each schema to optionally include an `id` field of a specific type (either `int` or `None`). The changes ensure that the API endpoints and data converters consistently use these generic types, improving clarity and type safety across object creation and retrieval operations.

Schema class refactoring and typing improvements:

* Made `AttributeTypeSchema`, `ObjectClassSchema`, and `EntityTypeSchema` generic classes parameterized by an `_IdT` type variable, and added an optional `id` field to each schema. This enables distinguishing between objects with and without IDs (e.g., for create vs. read operations). [[1]](diffhunk://#diff-dcb2f07424ed223107777ca8383fbbe5b4e8c28829505154521ccad404d3415dR7-R8) [[2]](diffhunk://#diff-dcb2f07424ed223107777ca8383fbbe5b4e8c28829505154521ccad404d3415dR18-R25) [[3]](diffhunk://#diff-dcb2f07424ed223107777ca8383fbbe5b4e8c28829505154521ccad404d3415dL42-R51) [[4]](diffhunk://#diff-dcb2f07424ed223107777ca8383fbbe5b4e8c28829505154521ccad404d3415dL67-R76)

API endpoint updates:

* Updated all `create_*` endpoints to accept schema objects without IDs (e.g., `AttributeTypeSchema[None]`), and all `get_*` endpoints to return schema objects with integer IDs (e.g., `AttributeTypeSchema[int]`). [[1]](diffhunk://#diff-71adff4b6c6f35b457b576c9d89ad8791e33d618528601ae954764edd022e3eaL27-R27) [[2]](diffhunk://#diff-71adff4b6c6f35b457b576c9d89ad8791e33d618528601ae954764edd022e3eaL38-R38) [[3]](diffhunk://#diff-c4b1a748ce388cd64cbfb81476d63f8c76aca79aa2eebb811ba0652216396fe6L25-R25) [[4]](diffhunk://#diff-c4b1a748ce388cd64cbfb81476d63f8c76aca79aa2eebb811ba0652216396fe6L36-R36) [[5]](diffhunk://#diff-9908ed3c632142329d80081292a0deae0eb85357f966ac9679eff5b52376d57fL25-R25) [[6]](diffhunk://#diff-9908ed3c632142329d80081292a0deae0eb85357f966ac9679eff5b52376d57fL36-R36)

Converter and adapter adjustments:

* Updated all uses of `get_converter` and related conversion logic in the adapter files to use the new generic schema types, ensuring correct mapping between DTOs and schemas with or without IDs. [[1]](diffhunk://#diff-456beafa146acaf783d13dbfb675de1d3f720aa213d3352552ca117989834b79L52-R52) [[2]](diffhunk://#diff-456beafa146acaf783d13dbfb675de1d3f720aa213d3352552ca117989834b79L73-R73) [[3]](diffhunk://#diff-5b20c1570fab196a2f8cc5e1c63f1f4b17d519f803b5d3eb368c07c47653fc1bL42-R47) [[4]](diffhunk://#diff-d5733e2d150cd85394d868d4f5706c9efa1c1e2ed6acc976c3b7263f3b2efc96L47-R47) [[5]](diffhunk://#diff-d5733e2d150cd85394d868d4f5706c9efa1c1e2ed6acc976c3b7263f3b2efc96L68-R68)

Code cleanup:

* Removed unused imports related to the old conversion logic in `entity_type.py`.