### PR TITLE
Fix password modify 741

### DIFF
--- a/app/ldap_protocol/identity/identity_manager.py
+++ b/app/ldap_protocol/identity/identity_manager.py
@@ -222,8 +222,9 @@ class IdentityManager(AbstractService):
                 f"User {identity} not found in the database.",
             )
 
-        uac_check = await get_check_uac(self._session, user.directory_id)
-        if uac_check(UserAccountControlFlag.PASSWD_CANT_CHANGE):
+        if await self._password_use_cases.password_cant_change(
+            user.directory_id,
+        ):
             raise PasswordPolicyError(
                 "User is not allowed to change the password.",
             )

--- a/app/ldap_protocol/identity/identity_manager.py
+++ b/app/ldap_protocol/identity/identity_manager.py
@@ -222,6 +222,12 @@ class IdentityManager(AbstractService):
                 f"User {identity} not found in the database.",
             )
 
+        uac_check = await get_check_uac(self._session, user.directory_id)
+        if uac_check(UserAccountControlFlag.PASSWD_CANT_CHANGE):
+            raise PasswordPolicyError(
+                "User is not allowed to change the password.",
+            )
+
         errors = await self._password_use_cases.check_password_violations(
             new_password,
             user,

--- a/app/ldap_protocol/ldap_requests/extended.py
+++ b/app/ldap_protocol/ldap_requests/extended.py
@@ -195,6 +195,11 @@ class PasswdModifyRequestValue(BaseExtendedValue):
 
             user = await ctx.session.get(User, ctx.ldap_session.user.id)  # type: ignore
 
+        if await ctx.password_use_cases.password_cant_change(
+            user.directory_id,
+        ):
+            raise PermissionError("Password cannot be changed")
+
         errors = await ctx.password_use_cases.check_password_violations(
             password=new_password,
             user=user,

--- a/app/ldap_protocol/policies/password/policies_dao.py
+++ b/app/ldap_protocol/policies/password/policies_dao.py
@@ -16,7 +16,10 @@ from ldap_protocol.policies.password.exceptions import (
     PasswordPolicyAlreadyExistsError,
     PasswordPolicyNotFoundError,
 )
-from ldap_protocol.user_account_control import UserAccountControlFlag
+from ldap_protocol.user_account_control import (
+    UserAccountControlFlag,
+    get_check_uac,
+)
 from ldap_protocol.utils.helpers import ft_now
 from models import Attribute, PasswordPolicy, User
 
@@ -157,3 +160,12 @@ class PasswordPolicyDAO(AbstractDAO[PasswordPolicyDTO, int]):
 
         user.password_history.append(user.password)
         await self._session.flush()
+
+    async def password_cant_change(self, user_directory_id: int) -> bool:
+        """Check if user is restricted from changing password via UAC flag.
+
+        :param int user_directory_id: user's directory ID
+        :return bool: True if user is restricted, False otherwise
+        """
+        uac_check = await get_check_uac(self._session, user_directory_id)
+        return uac_check(UserAccountControlFlag.PASSWD_CANT_CHANGE)

--- a/app/ldap_protocol/policies/password/use_cases.py
+++ b/app/ldap_protocol/policies/password/use_cases.py
@@ -177,3 +177,13 @@ class PasswordPolicyUseCases(AbstractService):
 
         await self.policy_validator.validate(password)
         return self.policy_validator._error_messages  # noqa: SLF001
+
+    async def password_cant_change(self, user_directory_id: int) -> bool:
+        """Check if user is restricted from changing password via UAC flag.
+
+        :param int user_directory_id: user's directory ID
+        :return bool: True if user is restricted, False otherwise
+        """
+        return await self.password_policy_dao.password_cant_change(
+            user_directory_id,
+        )


### PR DESCRIPTION
### Задача

Если у пользователя стоит запрет на смену пароля (в userAccountControl), то никто не должен иметь возможность изменить пароль этого пользователя.

### Решение

- В `PasswordPolicyUseCases` добавлен метод password_cant_change для проверки флага на запрет пароля;
- Этот метод применяется в 3 местах:
  - Изменение пароля через API, ручка - /auth/user/password;
  - Модификация пароля через Modify request;
  - Модификация пароля через Extended request;