### PR TITLE
Fix optimize ace inheritance 757

### DIFF
--- a/app/ldap_protocol/ldap_requests/modify_dn.py
+++ b/app/ldap_protocol/ldap_requests/modify_dn.py
@@ -226,7 +226,6 @@ class ModifyDNRequest(BaseRequest):
                 object_guid=directory.object_guid,
                 object_sid=directory.object_sid,
             )
-            ctx.session.add(new_directory)
             new_directory.create_path(parent_dir, dn=dn)
 
         try:

--- a/app/ldap_protocol/ldap_requests/modify_dn.py
+++ b/app/ldap_protocol/ldap_requests/modify_dn.py
@@ -234,7 +234,7 @@ class ModifyDNRequest(BaseRequest):
             await ctx.session.flush()
             if parent_dir:
                 await ctx.role_use_case.inherit_parent_aces(
-                    parent_directory=parent_dir,  # type: ignore
+                    parent_directory=parent_dir,
                     directory=new_directory,
                 )
                 await ctx.session.flush()

--- a/app/ldap_protocol/ldap_requests/modify_dn.py
+++ b/app/ldap_protocol/ldap_requests/modify_dn.py
@@ -189,11 +189,7 @@ class ModifyDNRequest(BaseRequest):
 
             ctx.session.add(new_directory)
             new_directory.create_path(directory.parent, dn)
-            if directory.parent:
-                await ctx.role_use_case.inherit_parent_aces(
-                    parent_directory=directory.parent,
-                    directory=new_directory,
-                )
+            parent_dir = directory.parent
 
         else:
             new_sup_query = select(Directory).filter(
@@ -206,14 +202,14 @@ class ModifyDNRequest(BaseRequest):
                 require_attribute_type_null=True,
             )
 
-            new_parent_dir = await ctx.session.scalar(new_sup_query)
+            parent_dir = await ctx.session.scalar(new_sup_query)
 
-            if not new_parent_dir:
+            if not parent_dir:
                 yield ModifyDNResponse(result_code=LDAPCodes.NO_SUCH_OBJECT)
                 return
 
             can_add = ctx.access_manager.check_entity_level_access(
-                aces=new_parent_dir.access_control_entries,
+                aces=parent_dir.access_control_entries,
                 entity_type_id=directory.entity_type_id,
             )
 
@@ -226,21 +222,22 @@ class ModifyDNRequest(BaseRequest):
             new_directory = Directory(
                 object_class=directory.object_class,
                 name=name,
-                parent=new_parent_dir,
+                parent=parent_dir,
                 object_guid=directory.object_guid,
                 object_sid=directory.object_sid,
             )
             ctx.session.add(new_directory)
-            new_directory.create_path(new_parent_dir, dn=dn)
-
-            await ctx.role_use_case.inherit_parent_aces(
-                parent_directory=new_parent_dir,
-                directory=new_directory,
-            )
+            new_directory.create_path(parent_dir, dn=dn)
 
         try:
             ctx.session.add(new_directory)
             await ctx.session.flush()
+            if parent_dir:
+                await ctx.role_use_case.inherit_parent_aces(
+                    parent_directory=parent_dir,  # type: ignore
+                    directory=new_directory,
+                )
+                await ctx.session.flush()
         except IntegrityError:
             await ctx.session.rollback()
             yield ModifyDNResponse(result_code=LDAPCodes.ENTRY_ALREADY_EXISTS)

--- a/app/ldap_protocol/roles/role_use_case.py
+++ b/app/ldap_protocol/roles/role_use_case.py
@@ -7,11 +7,16 @@ License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 from enum import StrEnum
 
 from sqlalchemy import and_, or_, select
-from sqlalchemy.orm import selectinload
 
 from enums import RoleScope
 from ldap_protocol.utils.queries import get_base_directories
-from models import AccessControlEntry, AceType, Directory, Role
+from models import (
+    AccessControlEntry,
+    AccessControlEntryDirectoryMembership,
+    AceType,
+    Directory,
+    Role,
+)
 
 from .ace_dao import AccessControlEntryDAO
 from .dataclasses import AccessControlEntryDTO, RoleDTO
@@ -60,23 +65,6 @@ class RoleUseCase:
         """
         directory_filter = Directory.id == parent_directory.id
 
-        subtree_inheritance = and_(
-            AccessControlEntry.depth != Directory.depth,
-            AccessControlEntry.scope == RoleScope.WHOLE_SUBTREE,
-        )
-
-        explicit_inheritance = and_(
-            AccessControlEntry.depth == Directory.depth,
-            AccessControlEntry.scope.in_(
-                [
-                    RoleScope.SINGLE_LEVEL,
-                    RoleScope.WHOLE_SUBTREE,
-                ],
-            ),
-        )
-
-        inheritance_conditions = or_(subtree_inheritance, explicit_inheritance)
-
         subquery = (
             select(Directory.id)
             .where(Directory.parent_id == parent_directory.id)
@@ -84,14 +72,14 @@ class RoleUseCase:
         )
 
         query = (
-            select(AccessControlEntry)
+            select(AccessControlEntry.id)
             .join(AccessControlEntry.directories)
-            .options(
-                selectinload(AccessControlEntry.directories),
-            )
             .where(
                 or_(
-                    and_(directory_filter, inheritance_conditions),
+                    and_(
+                        directory_filter,
+                        AccessControlEntry.scope == RoleScope.WHOLE_SUBTREE,
+                    ),
                     and_(
                         Directory.id.in_(subquery),
                         AccessControlEntry.scope == RoleScope.SINGLE_LEVEL,
@@ -102,10 +90,20 @@ class RoleUseCase:
             .distinct()
         )
 
-        aces = (await self._role_dao._session.execute(query)).scalars().all()  # noqa: SLF001
+        ace_ids = (
+            (await self._role_dao._session.execute(query)).scalars().all()  # noqa: SLF001
+        )
 
-        for ace in aces:
-            ace.directories.append(directory)
+        members = [
+            AccessControlEntryDirectoryMembership(
+                access_control_entry_id=ace_id,
+                directory_id=directory.id,
+            )
+            for ace_id in ace_ids
+        ]
+
+        if members:
+            self._role_dao._session.add_all(members)  # noqa: SLF001
 
     async def get_password_ace(
         self,

--- a/app/ldap_protocol/roles/role_use_case.py
+++ b/app/ldap_protocol/roles/role_use_case.py
@@ -82,7 +82,7 @@ class RoleUseCase:
                     ),
                 ),
             )
-        )
+        )  # fmt: skip
 
         ace_ids = (
             (await self._role_dao._session.execute(query)).scalars().all()  # noqa: SLF001

--- a/app/ldap_protocol/roles/role_use_case.py
+++ b/app/ldap_protocol/roles/role_use_case.py
@@ -84,9 +84,7 @@ class RoleUseCase:
             )
         )  # fmt: skip
 
-        ace_ids = (
-            (await self._role_dao._session.execute(query)).scalars().all()  # noqa: SLF001
-        )
+        ace_ids = (await self._role_dao._session.scalars(query)).all()  # noqa: SLF001
 
         members = [
             AccessControlEntryDirectoryMembership(

--- a/app/ldap_protocol/roles/role_use_case.py
+++ b/app/ldap_protocol/roles/role_use_case.py
@@ -84,7 +84,7 @@ class RoleUseCase:
             )
         )  # fmt: skip
 
-        ace_ids = (await self._role_dao._session.scalars(query)).all()  # noqa: SLF001
+        ace_ids = await self._role_dao._session.scalars(query)  # noqa: SLF001
 
         members = [
             AccessControlEntryDirectoryMembership(


### PR DESCRIPTION
### Задача

Необходимо оптимизировать наследование ACE.

### Решение

Большую часть времени занимал:

```python
.options(selectinload(AccessControlEntry.directories))
```

Вместо подгрузки relation, получаю только ACE IDs и делаю вставку в таблицу связи.