### PR TITLE
Fix user and computers deletion 761

### DIFF
--- a/.kerberos/config_server.py
+++ b/.kerberos/config_server.py
@@ -278,7 +278,14 @@ class KAdminLocalManager(AbstractKRBManager):
 
         :param str name: principal
         """
-        await self.loop.run_in_executor(self.pool, self.client.delprinc, name)
+        try:
+            await self.loop.run_in_executor(
+                self.pool,
+                self.client.delprinc,
+                name,
+            )
+        except kadmv.UnknownPrincipalError:
+            raise PrincipalNotFoundError
 
     async def rename_princ(self, name: str, new_name: str) -> None:
         """Rename principal.

--- a/app/ldap_protocol/kerberos/base.py
+++ b/app/ldap_protocol/kerberos/base.py
@@ -31,6 +31,10 @@ class KRBAPIError(Exception):
     """API Error."""
 
 
+class KRBAPIPrincipalNotFoundError(KRBAPIError):
+    """Principal not found error."""
+
+
 class AbstractKadmin(ABC):
     """Stub client for non set up dirs."""
 

--- a/app/ldap_protocol/kerberos/client.py
+++ b/app/ldap_protocol/kerberos/client.py
@@ -2,7 +2,7 @@
 
 import httpx
 
-from .base import AbstractKadmin, KRBAPIError
+from .base import AbstractKadmin, KRBAPIError, KRBAPIPrincipalNotFoundError
 from .utils import logger_wraps
 
 
@@ -34,6 +34,10 @@ class KerberosMDAPIClient(AbstractKadmin):
     async def get_principal(self, name: str) -> dict:
         """Get request."""
         response = await self.client.get("principal", params={"name": name})
+
+        if response.status_code == 404:
+            raise KRBAPIPrincipalNotFoundError
+
         if response.status_code != 200:
             raise KRBAPIError(response.text)
 
@@ -43,6 +47,10 @@ class KerberosMDAPIClient(AbstractKadmin):
     async def del_principal(self, name: str) -> None:
         """Delete principal."""
         response = await self.client.delete("principal", params={"name": name})
+
+        if response.status_code == 404:
+            raise KRBAPIPrincipalNotFoundError
+
         if response.status_code != 200:
             raise KRBAPIError(response.text)
 
@@ -71,6 +79,10 @@ class KerberosMDAPIClient(AbstractKadmin):
             "/principal/create_or_update",
             json={"name": name, "password": password},
         )
+
+        if response.status_code == 404:
+            raise KRBAPIPrincipalNotFoundError
+
         if response.status_code != 201:
             raise KRBAPIError(response.text)
 
@@ -98,7 +110,7 @@ class KerberosMDAPIClient(AbstractKadmin):
 
         response = await self.client.send(request, stream=True)
         if response.status_code == 404:
-            raise KRBAPIError("Principal not found")
+            raise KRBAPIPrincipalNotFoundError
 
         return response
 
@@ -114,6 +126,9 @@ class KerberosMDAPIClient(AbstractKadmin):
             json={"name": name},
         )
 
+        if response.status_code == 404:
+            raise KRBAPIPrincipalNotFoundError
+
         if response.status_code != 200:
             raise KRBAPIError(response.text)
 
@@ -127,6 +142,9 @@ class KerberosMDAPIClient(AbstractKadmin):
             "principal/force_reset",
             json={"name": name},
         )
+
+        if response.status_code == 404:
+            raise KRBAPIPrincipalNotFoundError
 
         if response.status_code != 200:
             raise KRBAPIError(response.text)

--- a/app/ldap_protocol/ldap_requests/delete.py
+++ b/app/ldap_protocol/ldap_requests/delete.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import defaultload, selectinload
 from enums import AceType
 from ldap_protocol.asn1parser import ASN1Row
 from ldap_protocol.kerberos import KRBAPIError
+from ldap_protocol.kerberos.base import KRBAPIPrincipalNotFoundError
 from ldap_protocol.ldap_codes import LDAPCodes
 from ldap_protocol.ldap_responses import (
     INVALID_ACCESS_RESPONSE,
@@ -120,16 +121,18 @@ class DeleteRequest(BaseRequest):
                         error_message="Cannot delete yourself.",
                     )
                     return
-                await ctx.kadmin.del_principal(directory.user.get_upn_prefix())
                 await ctx.session_storage.clear_user_sessions(
                     directory.user.id,
                 )
+                await ctx.kadmin.del_principal(directory.user.get_upn_prefix())
 
             if await is_computer(directory.id, ctx.session):
                 await ctx.kadmin.del_principal(directory.host_principal)
                 await ctx.kadmin.del_principal(
                     f"{directory.host_principal}.{base_dn.name}",
                 )
+        except KRBAPIPrincipalNotFoundError:
+            pass
         except KRBAPIError:
             yield DeleteResponse(
                 result_code=LDAPCodes.UNAVAILABLE,


### PR DESCRIPTION
### Задача

Кейс: удалить у компьютера\пользователя принципал и тогда возникнет ситуация бессмертных LDAP записей

### Решение

- в `kadmin_api` добавлена обработка исключения при удалении принципала;
- в клиенте добавлено исключение под статус код 404, который приходит из `kadmin_api`;
- в Delete-запросе пропускаем ошибку отсутствия принципала;