### PR TITLE
Fix session rekey

### DIFF
--- a/app/api/auth/oauth2.py
+++ b/app/api/auth/oauth2.py
@@ -76,11 +76,11 @@ async def get_current_user(
 
     session_id, _ = session_key.split(".")
     try:
-        if await session_storage.check_rekey(
+        key = await session_storage.rekey_session_if_needed(
             session_id,
-            settings.SESSION_REKEY_INTERVAL,
-        ):
-            key = await session_storage.rekey_session(session_id, settings)
+            settings,
+        )
+        if key:
             response.set_cookie(
                 key="id",
                 value=key,

--- a/app/ldap_protocol/session_storage/base.py
+++ b/app/ldap_protocol/session_storage/base.py
@@ -233,10 +233,14 @@ class SessionStorage(ABC):
         """
 
     @abstractmethod
-    async def rekey_session(self, session_id: str, settings: Settings) -> str:
-        """Rekey session.
+    async def rekey_session_if_needed(
+        self,
+        session_id: str,
+        settings: Settings,
+    ) -> str | None:
+        """Rekey session if needed.
 
         :param str session_id: session id
         :param Settings settings: app settings
-        :return str: jwt token
+        :return str | None: new session key or None
         """

--- a/tests/test_api/test_auth/test_sessions.py
+++ b/tests/test_api/test_auth/test_sessions.py
@@ -70,7 +70,9 @@ async def test_session_rekey(
     old_key = list(sessions.keys())[0]
     old_session = sessions[old_key]
 
-    await storage.rekey_session(old_key, settings)
+    # NOTE: set negative rekey interval to force rekey
+    settings.SESSION_REKEY_INTERVAL = -1
+    await storage.rekey_session_if_needed(old_key, settings)
     sessions = await storage.get_user_sessions(user.id)
 
     new_key = list(sessions.keys())[0]

--- a/tests/test_api/test_auth/test_sessions.py
+++ b/tests/test_api/test_auth/test_sessions.py
@@ -1,5 +1,7 @@
 """Test session workflow."""
 
+from typing import Iterator
+
 import pytest
 from aioldap3 import LDAPConnection
 from httpx import AsyncClient
@@ -49,8 +51,18 @@ async def test_session_creation(
     assert not await storage.get_user_sessions(user.id)
 
 
+@pytest.fixture
+def _force_override_rekey_interval(settings: Settings) -> Iterator:
+    """Override session rekey interval for tests."""
+    current_interval = settings.SESSION_REKEY_INTERVAL
+    settings.SESSION_REKEY_INTERVAL = -1
+    yield
+    settings.SESSION_REKEY_INTERVAL = current_interval
+
+
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("setup_session")
+@pytest.mark.usefixtures("_force_override_rekey_interval")
 async def test_session_rekey(
     unbound_http_client: AsyncClient,
     creds: TestCreds,
@@ -70,8 +82,6 @@ async def test_session_rekey(
     old_key = list(sessions.keys())[0]
     old_session = sessions[old_key]
 
-    # NOTE: set negative rekey interval to force rekey
-    settings.SESSION_REKEY_INTERVAL = -1
     await storage.rekey_session_if_needed(old_key, settings)
     sessions = await storage.get_user_sessions(user.id)
 


### PR DESCRIPTION
### Проблема

Блокировка по сессии была только в методе rekey_session, поэтому могла возникнуть ситуация, когда два запроса прошли check_rekey (на одной сессии одновременно) и оба попадают в rekey_session.

### Решение

Операции теперь выполняются атомарно под общей блокировкой.