### PR TITLE
Refactor ldap server

### DIFF
--- a/app/ioc.py
+++ b/app/ioc.py
@@ -66,6 +66,7 @@ from ldap_protocol.kerberos.ldap_structure import KRBLDAPStructureManager
 from ldap_protocol.kerberos.service import KerberosService
 from ldap_protocol.kerberos.template_render import KRBTemplateRenderer
 from ldap_protocol.ldap_requests.contexts import (
+    LDAPAbandonRequestContext,
     LDAPAddRequestContext,
     LDAPBindRequestContext,
     LDAPDeleteRequestContext,
@@ -509,6 +510,10 @@ class LDAPContextProvider(Provider):
     )
     search_request_context = provide(
         LDAPSearchRequestContext,
+        scope=Scope.REQUEST,
+    )
+    abandon_request_context = provide(
+        LDAPAbandonRequestContext,
         scope=Scope.REQUEST,
     )
 

--- a/app/ioc.py
+++ b/app/ioc.py
@@ -519,7 +519,7 @@ class LDAPContextProvider(Provider):
             yield session  # type: ignore
 
     @provide(scope=Scope.SESSION, provides=LDAPSearchRequestContext)
-    async def get_search_request_context(
+    def get_search_request_context(
         self,
         session: AsyncSessionSearchRequest,
         ldap_session: LDAPSession,

--- a/app/ioc.py
+++ b/app/ioc.py
@@ -535,6 +535,7 @@ class LDAPContextProvider(Provider):
             rootdse_rd=RootDSEReader(settings, SADomainGateway(session)),
         )
 
+
 class HTTPProvider(LDAPContextProvider):
     """HTTP LDAP session."""
 

--- a/app/ioc.py
+++ b/app/ioc.py
@@ -693,6 +693,23 @@ class HTTPProvider(LDAPContextProvider):
         scope=Scope.REQUEST,
     )
 
+    @provide(scope=Scope.REQUEST, provides=LDAPSearchRequestContext)
+    async def get_search_request_context(
+        self,
+        session: AsyncSession,
+        ldap_session: LDAPSession,
+        settings: Settings,
+        access_manager: AccessManager,
+    ) -> LDAPSearchRequestContext:
+        """Get search request context."""
+        return LDAPSearchRequestContext(
+            session=session,  # type: ignore
+            ldap_session=ldap_session,
+            settings=settings,
+            access_manager=access_manager,
+            rootdse_rd=RootDSEReader(settings, SADomainGateway(session)),
+        )
+
 
 class LDAPServerProvider(LDAPContextProvider):
     """Provider with session scope."""

--- a/app/ioc.py
+++ b/app/ioc.py
@@ -66,6 +66,7 @@ from ldap_protocol.kerberos.ldap_structure import KRBLDAPStructureManager
 from ldap_protocol.kerberos.service import KerberosService
 from ldap_protocol.kerberos.template_render import KRBTemplateRenderer
 from ldap_protocol.ldap_requests.contexts import (
+    AsyncSessionSearchRequest,
     LDAPAddRequestContext,
     LDAPBindRequestContext,
     LDAPDeleteRequestContext,
@@ -458,7 +459,7 @@ class MainProvider(Provider):
     )
     password_utils = provide(PasswordUtils, scope=Scope.RUNTIME)
 
-    access_manager = provide(AccessManager, scope=Scope.REQUEST)
+    access_manager = provide(AccessManager, scope=Scope.RUNTIME)
     role_dao = provide(RoleDAO, scope=Scope.REQUEST)
     ace_dao = provide(AccessControlEntryDAO, scope=Scope.REQUEST)
     role_use_case = provide(RoleUseCase, scope=Scope.REQUEST)
@@ -503,15 +504,36 @@ class LDAPContextProvider(Provider):
         LDAPModifyDNRequestContext,
         scope=Scope.REQUEST,
     )
-    search_request_context = provide(
-        LDAPSearchRequestContext,
-        scope=Scope.REQUEST,
-    )
     unbind_request_context = provide(
         LDAPUnbindRequestContext,
         scope=Scope.REQUEST,
     )
 
+    @provide(scope=Scope.SESSION)
+    async def create_search_session(
+        self,
+        async_session: async_sessionmaker[AsyncSession],
+    ) -> AsyncIterator[AsyncSessionSearchRequest]:
+        """Create session for request."""
+        async with async_session() as session:
+            yield session  # type: ignore
+
+    @provide(scope=Scope.SESSION, provides=LDAPSearchRequestContext)
+    async def get_search_request_context(
+        self,
+        session: AsyncSessionSearchRequest,
+        ldap_session: LDAPSession,
+        settings: Settings,
+        access_manager: AccessManager,
+    ) -> LDAPSearchRequestContext:
+        """Get search request context."""
+        return LDAPSearchRequestContext(
+            session=session,
+            ldap_session=ldap_session,
+            settings=settings,
+            access_manager=access_manager,
+            rootdse_rd=RootDSEReader(settings, SADomainGateway(session)),
+        )
 
 class HTTPProvider(LDAPContextProvider):
     """HTTP LDAP session."""

--- a/app/ioc.py
+++ b/app/ioc.py
@@ -66,7 +66,6 @@ from ldap_protocol.kerberos.ldap_structure import KRBLDAPStructureManager
 from ldap_protocol.kerberos.service import KerberosService
 from ldap_protocol.kerberos.template_render import KRBTemplateRenderer
 from ldap_protocol.ldap_requests.contexts import (
-    AsyncSessionSearchRequest,
     LDAPAddRequestContext,
     LDAPBindRequestContext,
     LDAPDeleteRequestContext,
@@ -508,32 +507,10 @@ class LDAPContextProvider(Provider):
         LDAPUnbindRequestContext,
         scope=Scope.REQUEST,
     )
-
-    @provide(scope=Scope.SESSION)
-    async def create_search_session(
-        self,
-        async_session: async_sessionmaker[AsyncSession],
-    ) -> AsyncIterator[AsyncSessionSearchRequest]:
-        """Create session for request."""
-        async with async_session() as session:
-            yield session  # type: ignore
-
-    @provide(scope=Scope.SESSION, provides=LDAPSearchRequestContext)
-    def get_search_request_context(
-        self,
-        session: AsyncSessionSearchRequest,
-        ldap_session: LDAPSession,
-        settings: Settings,
-        access_manager: AccessManager,
-    ) -> LDAPSearchRequestContext:
-        """Get search request context."""
-        return LDAPSearchRequestContext(
-            session=session,
-            ldap_session=ldap_session,
-            settings=settings,
-            access_manager=access_manager,
-            rootdse_rd=RootDSEReader(settings, SADomainGateway(session)),
-        )
+    search_request_context = provide(
+        LDAPSearchRequestContext,
+        scope=Scope.REQUEST,
+    )
 
 
 class HTTPProvider(LDAPContextProvider):
@@ -693,23 +670,6 @@ class HTTPProvider(LDAPContextProvider):
         NetworkPolicyFastAPIAdapter,
         scope=Scope.REQUEST,
     )
-
-    @provide(scope=Scope.REQUEST, provides=LDAPSearchRequestContext)
-    async def get_search_request_context(
-        self,
-        session: AsyncSession,
-        ldap_session: LDAPSession,
-        settings: Settings,
-        access_manager: AccessManager,
-    ) -> LDAPSearchRequestContext:
-        """Get search request context."""
-        return LDAPSearchRequestContext(
-            session=session,  # type: ignore
-            ldap_session=ldap_session,
-            settings=settings,
-            access_manager=access_manager,
-            rootdse_rd=RootDSEReader(settings, SADomainGateway(session)),
-        )
 
 
 class LDAPServerProvider(LDAPContextProvider):

--- a/app/ioc.py
+++ b/app/ioc.py
@@ -214,7 +214,7 @@ class MainProvider(Provider):
             yield KadminHTTPClient(client)
 
     @provide(scope=Scope.REQUEST)
-    async def get_kadmin(
+    def get_kadmin(
         self,
         client: KadminHTTPClient,
         kadmin_class: type[AbstractKadmin],
@@ -269,14 +269,14 @@ class MainProvider(Provider):
             yield DNSManagerHTTPClient(client)
 
     @provide(scope=Scope.REQUEST)
-    async def get_dns_mngr(
+    def get_dns_mngr(
         self,
         settings: DNSManagerSettings,
         dns_manager_class: type[AbstractDNSManager],
         http_client: DNSManagerHTTPClient,
-    ) -> AsyncIterator[AbstractDNSManager]:
+    ) -> AbstractDNSManager:
         """Get DNSManager class."""
-        yield dns_manager_class(settings=settings, http_client=http_client)
+        return dns_manager_class(settings=settings, http_client=http_client)
 
     @provide(scope=Scope.APP)
     async def get_redis_for_sessions(
@@ -293,7 +293,7 @@ class MainProvider(Provider):
         await client.aclose()
 
     @provide(scope=Scope.APP)
-    async def get_session_storage(
+    def get_session_storage(
         self,
         client: SessionStorageClient,
         settings: Settings,
@@ -306,7 +306,7 @@ class MainProvider(Provider):
         )
 
     @provide()
-    async def get_normalized_audit_event(
+    def get_normalized_audit_event(
         self,
     ) -> type[NormalizedAuditEvent]:
         """Get normalized audit event class."""
@@ -327,13 +327,13 @@ class MainProvider(Provider):
         await client.aclose()
 
     @provide(scope=Scope.APP)
-    async def get_raw_audit_manager(
+    def get_raw_audit_manager(
         self,
         client: AuditRedisClient,
         settings: Settings,
-    ) -> AsyncIterator[RawAuditManager]:
+    ) -> RawAuditManager:
         """Get raw audit manager."""
-        yield RawAuditManager(
+        return RawAuditManager(
             client,
             settings.RAW_EVENT_STREAM_NAME,
             settings.EVENT_HANDLER_GROUP,
@@ -342,13 +342,13 @@ class MainProvider(Provider):
         )
 
     @provide(scope=Scope.APP)
-    async def get_normalized_audit_manager(
+    def get_normalized_audit_manager(
         self,
         client: AuditRedisClient,
         settings: Settings,
-    ) -> AsyncIterator[NormalizedAuditManager]:
+    ) -> NormalizedAuditManager:
         """Get raw audit manager."""
-        yield NormalizedAuditManager(
+        return NormalizedAuditManager(
             client,
             settings.NORMALIZED_EVENT_STREAM_NAME,
             settings.EVENT_SENDER_GROUP,
@@ -361,7 +361,7 @@ class MainProvider(Provider):
     audit_destination_dao = provide(AuditDestinationDAO, scope=Scope.REQUEST)
 
     @provide(scope=Scope.REQUEST)
-    async def get_dhcp_manager_repository(
+    def get_dhcp_manager_repository(
         self,
         session: AsyncSession,
     ) -> DHCPManagerRepository:
@@ -377,20 +377,20 @@ class MainProvider(Provider):
         return await dhcp_manager_repository.ensure_state()
 
     @provide(scope=Scope.REQUEST)
-    async def get_dhcp_mngr_class(
+    def get_dhcp_mngr_class(
         self,
         dhcp_state: DHCPManagerState,
     ) -> type[AbstractDHCPManager]:
         """Get DHCP manager type."""
-        return await get_dhcp_manager_class(dhcp_state)
+        return get_dhcp_manager_class(dhcp_state)
 
     @provide(scope=Scope.REQUEST)
-    async def get_dhcp_api_repository_class(
+    def get_dhcp_api_repository_class(
         self,
         dhcp_state: DHCPManagerState,
     ) -> type[DHCPAPIRepository]:
         """Get DHCP API repository type."""
-        return await get_dhcp_api_repository_class(dhcp_state)
+        return get_dhcp_api_repository_class(dhcp_state)
 
     @provide(scope=Scope.APP)
     async def get_dhcp_http_client(
@@ -404,7 +404,7 @@ class MainProvider(Provider):
             yield DHCPManagerHTTPClient(http_client)
 
     @provide(scope=Scope.REQUEST)
-    async def get_dhcp_api_repository(
+    def get_dhcp_api_repository(
         self,
         http_client: DHCPManagerHTTPClient,
         dhcp_api_repository_class: type[DHCPAPIRepository],
@@ -413,7 +413,7 @@ class MainProvider(Provider):
         return dhcp_api_repository_class(http_client)
 
     @provide(scope=Scope.REQUEST)
-    async def get_dhcp_mngr(
+    def get_dhcp_mngr(
         self,
         dhcp_manager_class: type[AbstractDHCPManager],
         dhcp_api_repository: DHCPAPIRepository,
@@ -535,7 +535,7 @@ class HTTPProvider(LDAPContextProvider):
     )
 
     @provide()
-    async def get_audit_monitor(
+    def get_audit_monitor(
         self,
         session: AsyncSession,
         audit_use_case: "AuditUseCase",
@@ -595,7 +595,7 @@ class HTTPProvider(LDAPContextProvider):
         return auth_provider
 
     @provide()
-    async def get_identity_provider(
+    def get_identity_provider(
         self,
         request: Request,
         session_storage: SessionStorage,
@@ -816,7 +816,7 @@ class MFAProvider(Provider):
             yield MFAHTTPClient(client)
 
     @provide(provides=MultifactorAPI)
-    async def get_http_mfa(
+    def get_http_mfa(
         self,
         credentials: MFA_HTTP_Creds,
         client: MFAHTTPClient,
@@ -838,7 +838,7 @@ class MFAProvider(Provider):
         )
 
     @provide(provides=LDAPMultiFactorAPI)
-    async def get_ldap_mfa(
+    def get_ldap_mfa(
         self,
         credentials: MFA_LDAP_Creds,
         client: MFAHTTPClient,

--- a/app/ldap_protocol/dhcp/__init__.py
+++ b/app/ldap_protocol/dhcp/__init__.py
@@ -26,7 +26,7 @@ from .schemas import (
 from .stub import StubDHCPAPIRepository, StubDHCPManager
 
 
-async def get_dhcp_manager_class(
+def get_dhcp_manager_class(
     dhcp_state: DHCPManagerState,
 ) -> type[AbstractDHCPManager]:
     """Get an instance of the DHCP manager."""
@@ -35,7 +35,7 @@ async def get_dhcp_manager_class(
     return StubDHCPManager
 
 
-async def get_dhcp_api_repository_class(
+def get_dhcp_api_repository_class(
     dhcp_state: DHCPManagerState,
 ) -> type[DHCPAPIRepository]:
     """Get an instance of the DHCP API repository."""

--- a/app/ldap_protocol/ldap_requests/abandon.py
+++ b/app/ldap_protocol/ldap_requests/abandon.py
@@ -27,7 +27,7 @@ class AbandonRequest(BaseRequest):
         """Create structure from ASN1Row dataclass list."""
         return cls(message_id=1)
 
-    async def handle(self, ctx) -> AsyncGenerator:  # type: ignore
+    async def handle(self, ctx: None) -> AsyncGenerator:  # noqa: ARG002
         """Handle message with current user."""
         await asyncio.sleep(0)
         return

--- a/app/ldap_protocol/ldap_requests/abandon.py
+++ b/app/ldap_protocol/ldap_requests/abandon.py
@@ -27,7 +27,7 @@ class AbandonRequest(BaseRequest):
         """Create structure from ASN1Row dataclass list."""
         return cls(message_id=1)
 
-    async def handle(self) -> AsyncGenerator:
+    async def handle(self, ctx) -> AsyncGenerator:  # type: ignore
         """Handle message with current user."""
         await asyncio.sleep(0)
         return

--- a/app/ldap_protocol/ldap_requests/abandon.py
+++ b/app/ldap_protocol/ldap_requests/abandon.py
@@ -8,6 +8,7 @@ import asyncio
 from typing import AsyncGenerator, ClassVar
 
 from ldap_protocol.asn1parser import ASN1Row
+from ldap_protocol.ldap_requests.contexts import LDAPAbandonRequestContext
 from ldap_protocol.objects import ProtocolRequests
 
 from .base import BaseRequest
@@ -16,6 +17,7 @@ from .base import BaseRequest
 class AbandonRequest(BaseRequest):
     """Abandon protocol."""
 
+    CONTEXT_TYPE: ClassVar[type] = LDAPAbandonRequestContext
     PROTOCOL_OP: ClassVar[int] = ProtocolRequests.ABANDON
     message_id: int
 
@@ -27,7 +29,7 @@ class AbandonRequest(BaseRequest):
         """Create structure from ASN1Row dataclass list."""
         return cls(message_id=1)
 
-    async def handle(self, ctx: None) -> AsyncGenerator:  # noqa: ARG002
+    async def handle(self, ctx: LDAPAbandonRequestContext) -> AsyncGenerator:  # noqa: ARG002
         """Handle message with current user."""
         await asyncio.sleep(0)
         return

--- a/app/ldap_protocol/ldap_requests/add.py
+++ b/app/ldap_protocol/ldap_requests/add.py
@@ -65,6 +65,7 @@ class AddRequest(BaseRequest):
     """
 
     PROTOCOL_OP: ClassVar[int] = ProtocolRequests.ADD
+    CONTEXT_TYPE: ClassVar[type] = LDAPAddRequestContext
 
     entry: str = Field(..., description="Any `DistinguishedName`")
     attributes: list[PartialAttribute]

--- a/app/ldap_protocol/ldap_requests/base.py
+++ b/app/ldap_protocol/ldap_requests/base.py
@@ -115,10 +115,7 @@ class BaseRequest(ABC, _APIProtocol, BaseModel):
         container: AsyncContainer,
     ) -> AsyncIterator[BaseResponse]:
         """Hanlde response with tcp."""
-        if self.PROTOCOL_OP != ProtocolRequests.ABANDON:
-            ctx = await container.get(self.CONTEXT_TYPE)  # type: ignore
-        else:
-            ctx = None
+        ctx = await container.get(self.CONTEXT_TYPE)  # type: ignore
 
         responses = []
         async for response in self.handle(ctx=ctx):
@@ -162,10 +159,7 @@ class BaseRequest(ABC, _APIProtocol, BaseModel):
         :param AsyncSession session: db session
         :return list[BaseResponse]: list of handled responses
         """
-        if self.PROTOCOL_OP != ProtocolRequests.ABANDON:
-            ctx = await container.get(self.CONTEXT_TYPE)  # type: ignore
-        else:
-            ctx = None
+        ctx = await container.get(self.CONTEXT_TYPE)  # type: ignore
 
         ldap_session = await container.get(LDAPSession)
         settings = await container.get(Settings)

--- a/app/ldap_protocol/ldap_requests/bind.py
+++ b/app/ldap_protocol/ldap_requests/bind.py
@@ -43,6 +43,7 @@ class BindRequest(BaseRequest):
     """Bind request fields mapping."""
 
     PROTOCOL_OP: ClassVar[int] = ProtocolRequests.BIND
+    CONTEXT_TYPE: ClassVar[type] = LDAPBindRequestContext
 
     version: int
     name: str
@@ -230,6 +231,7 @@ class UnbindRequest(BaseRequest):
     """Remove user from ldap_session."""
 
     PROTOCOL_OP: ClassVar[int] = ProtocolRequests.UNBIND
+    CONTEXT_TYPE: ClassVar[type] = LDAPUnbindRequestContext
 
     @classmethod
     def from_data(

--- a/app/ldap_protocol/ldap_requests/contexts.py
+++ b/app/ldap_protocol/ldap_requests/contexts.py
@@ -5,6 +5,7 @@ License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
 
 from dataclasses import dataclass
+from typing import NewType
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -24,6 +25,7 @@ from ldap_protocol.rootdse.reader import RootDSEReader
 from ldap_protocol.session_storage import SessionStorage
 from password_utils import PasswordUtils
 
+AsyncSessionSearchRequest = NewType("AsyncSessionSearchRequest", AsyncSession)
 
 @dataclass
 class LDAPAddRequestContext:
@@ -74,7 +76,7 @@ class LDAPBindRequestContext:
 class LDAPSearchRequestContext:
     """Context for LDAP search request."""
 
-    session: AsyncSession
+    session: AsyncSessionSearchRequest
     ldap_session: LDAPSession
     settings: Settings
     access_manager: AccessManager

--- a/app/ldap_protocol/ldap_requests/contexts.py
+++ b/app/ldap_protocol/ldap_requests/contexts.py
@@ -27,6 +27,7 @@ from password_utils import PasswordUtils
 
 AsyncSessionSearchRequest = NewType("AsyncSessionSearchRequest", AsyncSession)
 
+
 @dataclass
 class LDAPAddRequestContext:
     """Context for LDAP add request."""

--- a/app/ldap_protocol/ldap_requests/contexts.py
+++ b/app/ldap_protocol/ldap_requests/contexts.py
@@ -123,3 +123,7 @@ class LDAPModifyDNRequestContext:
     access_manager: AccessManager
     role_use_case: RoleUseCase
     attribute_value_validator: AttributeValueValidator
+
+@dataclass
+class LDAPAbandonRequestContext:
+    ...

--- a/app/ldap_protocol/ldap_requests/contexts.py
+++ b/app/ldap_protocol/ldap_requests/contexts.py
@@ -124,6 +124,6 @@ class LDAPModifyDNRequestContext:
     role_use_case: RoleUseCase
     attribute_value_validator: AttributeValueValidator
 
+
 @dataclass
-class LDAPAbandonRequestContext:
-    ...
+class LDAPAbandonRequestContext: ...

--- a/app/ldap_protocol/ldap_requests/contexts.py
+++ b/app/ldap_protocol/ldap_requests/contexts.py
@@ -5,7 +5,6 @@ License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
 
 from dataclasses import dataclass
-from typing import NewType
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -24,8 +23,6 @@ from ldap_protocol.roles.role_use_case import RoleUseCase
 from ldap_protocol.rootdse.reader import RootDSEReader
 from ldap_protocol.session_storage import SessionStorage
 from password_utils import PasswordUtils
-
-AsyncSessionSearchRequest = NewType("AsyncSessionSearchRequest", AsyncSession)
 
 
 @dataclass
@@ -77,7 +74,7 @@ class LDAPBindRequestContext:
 class LDAPSearchRequestContext:
     """Context for LDAP search request."""
 
-    session: AsyncSessionSearchRequest
+    session: AsyncSession
     ldap_session: LDAPSession
     settings: Settings
     access_manager: AccessManager

--- a/app/ldap_protocol/ldap_requests/delete.py
+++ b/app/ldap_protocol/ldap_requests/delete.py
@@ -43,6 +43,7 @@ class DeleteRequest(BaseRequest):
     """
 
     PROTOCOL_OP: ClassVar[int] = ProtocolRequests.DELETE
+    CONTEXT_TYPE: ClassVar[type] = LDAPDeleteRequestContext
 
     entry: str
 

--- a/app/ldap_protocol/ldap_requests/extended.py
+++ b/app/ldap_protocol/ldap_requests/extended.py
@@ -308,6 +308,7 @@ class ExtendedRequest(BaseRequest):
     """
 
     PROTOCOL_OP: ClassVar[int] = ProtocolRequests.EXTENDED
+    CONTEXT_TYPE: ClassVar[type] = LDAPExtendedRequestContext
     request_name: LDAPOID
     request_value: SerializeAsAny[BaseExtendedValue]
 

--- a/app/ldap_protocol/ldap_requests/modify.py
+++ b/app/ldap_protocol/ldap_requests/modify.py
@@ -102,6 +102,7 @@ class ModifyRequest(BaseRequest):
     """
 
     PROTOCOL_OP: ClassVar[int] = ProtocolRequests.MODIFY
+    CONTEXT_TYPE: ClassVar[type] = LDAPModifyRequestContext
 
     object: str
     changes: list[Changes]

--- a/app/ldap_protocol/ldap_requests/modify_dn.py
+++ b/app/ldap_protocol/ldap_requests/modify_dn.py
@@ -68,6 +68,7 @@ class ModifyDNRequest(BaseRequest):
     """
 
     PROTOCOL_OP: ClassVar[int] = ProtocolRequests.MODIFY_DN
+    CONTEXT_TYPE: ClassVar[type] = LDAPModifyDNRequestContext
 
     entry: str
     newrdn: str

--- a/app/ldap_protocol/ldap_requests/search.py
+++ b/app/ldap_protocol/ldap_requests/search.py
@@ -367,7 +367,7 @@ class SearchRequest(BaseRequest):
             select(Directory)
             .join(qa(Directory.user), isouter=True)
             .options(joinedload(qa(Directory.user)))
-            .options(selectinload(qa(Directory.group)))
+            .options(joinedload(qa(Directory.group)))
         )
 
         query = self._mutate_query_with_attributes_to_load(query)

--- a/app/ldap_protocol/ldap_requests/search.py
+++ b/app/ldap_protocol/ldap_requests/search.py
@@ -337,10 +337,7 @@ class SearchRequest(BaseRequest):
     ) -> Select:
         """Get attributes to load."""
         if self.entity_type_name:
-            query = (
-                query.join(qa(Directory.entity_type))
-                .options(selectinload(qa(Directory.entity_type)))
-            )  # fmt: skip
+            query = query.options(joinedload(qa(Directory.entity_type)))
 
         if self.all_attrs:
             return query.options(selectinload(qa(Directory.attributes)))

--- a/app/ldap_protocol/ldap_requests/search.py
+++ b/app/ldap_protocol/ldap_requests/search.py
@@ -337,7 +337,10 @@ class SearchRequest(BaseRequest):
     ) -> Select:
         """Get attributes to load."""
         if self.entity_type_name:
-            query = query.options(joinedload(qa(Directory.entity_type)))
+            query = (
+                query.join(qa(Directory.entity_type))
+                .options(contains_eager(qa(Directory.entity_type)))
+            )  # fmt: skip
 
         if self.all_attrs:
             return query.options(selectinload(qa(Directory.attributes)))
@@ -366,7 +369,7 @@ class SearchRequest(BaseRequest):
         query = (
             select(Directory)
             .join(qa(Directory.user), isouter=True)
-            .options(joinedload(qa(Directory.user)))
+            .options(contains_eager(qa(Directory.user)))
             .options(joinedload(qa(Directory.group)))
         )
 

--- a/app/ldap_protocol/ldap_requests/search.py
+++ b/app/ldap_protocol/ldap_requests/search.py
@@ -14,7 +14,12 @@ from loguru import logger
 from pydantic import Field, PrivateAttr, field_serializer
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload, selectinload, with_loader_criteria
+from sqlalchemy.orm import (
+    contains_eager,
+    joinedload,
+    selectinload,
+    with_loader_criteria,
+)
 from sqlalchemy.sql.elements import ColumnElement, UnaryExpression
 from sqlalchemy.sql.expression import Select
 

--- a/app/ldap_protocol/ldap_requests/search.py
+++ b/app/ldap_protocol/ldap_requests/search.py
@@ -538,9 +538,9 @@ class SearchRequest(BaseRequest):
         access_manager: AccessManager,
     ) -> AsyncGenerator[SearchResultEntry, None]:
         """Yield all resulted directories."""
-        directories = await session.stream_scalars(query)
+        directories = await session.scalars(query)
 
-        async for directory in directories:
+        for directory in directories:
             attrs = defaultdict(list)
             obj_classes = []
 

--- a/app/ldap_protocol/ldap_requests/search.py
+++ b/app/ldap_protocol/ldap_requests/search.py
@@ -105,6 +105,7 @@ class SearchRequest(BaseRequest):
     """
 
     PROTOCOL_OP: ClassVar[int] = ProtocolRequests.SEARCH
+    CONTEXT_TYPE: ClassVar[type] = LDAPSearchRequestContext
 
     base_object: str = Field("", description="Any `DistinguishedName`")
     scope: Scope

--- a/app/ldap_protocol/ldap_requests/search.py
+++ b/app/ldap_protocol/ldap_requests/search.py
@@ -507,7 +507,6 @@ class SearchRequest(BaseRequest):
                     )
 
         if self.member_of:
-            logger.debug(f"Member of group: {directory.groups}")
             for group in directory.groups:
                 attrs["memberOf"].append(group.directory.path_dn)
 

--- a/app/ldap_protocol/ldap_requests/search.py
+++ b/app/ldap_protocol/ldap_requests/search.py
@@ -420,7 +420,7 @@ class SearchRequest(BaseRequest):
 
         if self.member:
             query = query.options(
-                selectinload(qa(Directory.group)).selectinload(
+                joinedload(qa(Directory.group)).selectinload(
                     qa(Group.members),
                 ),
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -665,10 +665,25 @@ class TestProvider(Provider):
         LDAPModifyDNRequestContext,
         scope=Scope.REQUEST,
     )
-    search_request_context = provide(
-        LDAPSearchRequestContext,
-        scope=Scope.REQUEST,
-    )
+
+    @provide(scope=Scope.REQUEST, provides=LDAPSearchRequestContext)
+    def get_search_request_context(
+        self,
+        session: AsyncSession,
+        ldap_session: LDAPSession,
+        settings: Settings,
+        access_manager: AccessManager,
+        rootdse_reader: RootDSEReader,
+    ) -> LDAPSearchRequestContext:
+        """Get search request context."""
+        return LDAPSearchRequestContext(
+            session=session,  # type: ignore
+            ldap_session=ldap_session,
+            settings=settings,
+            access_manager=access_manager,
+            rootdse_rd=rootdse_reader,
+        )
+
     unbind_request_context = provide(
         LDAPUnbindRequestContext,
         scope=Scope.REQUEST,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -665,24 +665,10 @@ class TestProvider(Provider):
         LDAPModifyDNRequestContext,
         scope=Scope.REQUEST,
     )
-
-    @provide(scope=Scope.REQUEST, provides=LDAPSearchRequestContext)
-    def get_search_request_context(
-        self,
-        session: AsyncSession,
-        ldap_session: LDAPSession,
-        settings: Settings,
-        access_manager: AccessManager,
-        rootdse_reader: RootDSEReader,
-    ) -> LDAPSearchRequestContext:
-        """Get search request context."""
-        return LDAPSearchRequestContext(
-            session=session,  # type: ignore
-            ldap_session=ldap_session,
-            settings=settings,
-            access_manager=access_manager,
-            rootdse_rd=rootdse_reader,
-        )
+    search_request_context = provide(
+        LDAPSearchRequestContext,
+        scope=Scope.REQUEST,
+    )
 
     unbind_request_context = provide(
         LDAPUnbindRequestContext,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,6 +87,7 @@ from ldap_protocol.kerberos.service import KerberosService
 from ldap_protocol.kerberos.template_render import KRBTemplateRenderer
 from ldap_protocol.ldap_requests.bind import BindRequest
 from ldap_protocol.ldap_requests.contexts import (
+    LDAPAbandonRequestContext,
     LDAPAddRequestContext,
     LDAPBindRequestContext,
     LDAPDeleteRequestContext,
@@ -667,6 +668,10 @@ class TestProvider(Provider):
     )
     search_request_context = provide(
         LDAPSearchRequestContext,
+        scope=Scope.REQUEST,
+    )
+    abandon_request_context = provide(
+        LDAPAbandonRequestContext,
         scope=Scope.REQUEST,
     )
 


### PR DESCRIPTION
### Изменения

1. Добавлен CONTEXT_TYPE во все LDAP запросы, чтобы избежать лишних вызовов `resolve_deps`.
2. Перевод провайдеров в sync версии, чтобы разгрузить получение асинхронных зависимостей.
3. [SearchRequest] Убрано безусловное получение зависимостей для аудита из контейнера.
4. [SearchRequest] Убран лишний запрос на Directory.entity_type.
5. [SearchRequest] Убран лишний joinedload(qa(Directory.user)).
6. [SearchRequest] Подгрузка группы для атрибута member заменена c selectinload на джоин.
7. [SearchRequest] stream_scalars -> scalars - изменение показало существенный прирост в скорости.