### PR TITLE
Refactor: merge enterprise tests

### DIFF
--- a/app/ldap_protocol/ldap_requests/modify.py
+++ b/app/ldap_protocol/ldap_requests/modify.py
@@ -149,7 +149,7 @@ class ModifyRequest(BaseRequest):
         now = datetime.now(timezone.utc) + timedelta(days=max_age_days)
         change.modification.vals[0] = now.strftime("%Y%m%d%H%M%SZ")
 
-    async def handle(  # noqa: C901
+    async def handle(
         self,
         ctx: LDAPModifyRequestContext,
     ) -> AsyncGenerator[ModifyResponse, None]:
@@ -182,12 +182,6 @@ class ModifyRequest(BaseRequest):
 
         if not directory:
             yield ModifyResponse(result_code=LDAPCodes.NO_SUCH_OBJECT)
-            return
-
-        if directory.is_system:
-            yield ModifyResponse(
-                result_code=LDAPCodes.UNWILLING_TO_PERFORM,
-            )
             return
 
         can_modify = ctx.access_manager.check_modify_access(

--- a/docker-compose.remote.test.yml
+++ b/docker-compose.remote.test.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_PASSWORD: password123
       SECRET_KEY: 6a0452ae20cab4e21b6e9d18fa4b7bf397dd66ec3968b2d7407694278fd84cce
       POSTGRES_HOST: postgres
-    command: sh -c "python -m pytest -n auto -W ignore::DeprecationWarning -vv"
+    command: sh -c "python -m pytest -n auto -W ignore::DeprecationWarning -W ignore::coverage.exceptions.CoverageWarning -vv"
 
   postgres:
     image: postgres:16

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -20,7 +20,7 @@ services:
       POSTGRES_HOST: postgres
       # PYTHONTRACEMALLOC: 1
       PYTHONDONTWRITEBYTECODE: 1
-    command: sh -c "python -B -m pytest -n auto -x -W ignore::DeprecationWarning -vv"
+    command: sh -c "python -B -m pytest -n auto -x -W ignore::DeprecationWarning -W ignore::coverage.exceptions.CoverageWarning -vv"
     tty: true
 
   postgres:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,9 @@ show_missing = true
 
 [tool.coverage.run]
 concurrency = ["thread", "gevent"]
+omit = [
+    "*/__dishka_factory_*",
+]
 
 # RUFF
 # Ruff is a linter, not a type checker.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,9 +154,9 @@ from ldap_protocol.rootdse.reader import DCInfoReader, RootDSEReader
 from ldap_protocol.server import PoolClientHandler
 from ldap_protocol.session_storage import RedisSessionStorage, SessionStorage
 from ldap_protocol.session_storage.repository import SessionRepository
-from ldap_protocol.utils.queries import get_base_directories, get_user
+from ldap_protocol.utils.queries import get_user
 from password_utils import PasswordUtils
-from tests.constants import TEST_DATA, TEST_SYSTEM_ADMIN_DATA
+from tests.constants import TEST_DATA
 
 
 class TestProvider(Provider):
@@ -407,15 +407,16 @@ class TestProvider(Provider):
         self._cached_session = async_session
         self._session_id = uuid.uuid4()
 
-        yield async_session
+        try:
+            yield async_session
+        finally:
+            self._cached_session = None
+            self._session_id = None
 
-        self._cached_session = None
-        self._session_id = None
-
-        async_session.expire_all()
-        await trans.rollback()
-        await async_session.close()
-        await connection.close()
+            async_session.expire_all()
+            await trans.rollback()
+            await async_session.close()
+            await connection.close()
 
     @provide(scope=Scope.SESSION)
     async def get_ldap_session(
@@ -987,14 +988,6 @@ async def setup_session(
         dn="md.test",
         data=TEST_DATA,
         is_system=False,
-    )
-
-    domain = (await get_base_directories(session))[0]
-    await setup_gateway.create_dir(
-        data=TEST_SYSTEM_ADMIN_DATA,
-        is_system=True,
-        domain=domain,
-        parent=domain,
     )
 
     # NOTE: after setup environment we need base DN to be created

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -407,16 +407,15 @@ class TestProvider(Provider):
         self._cached_session = async_session
         self._session_id = uuid.uuid4()
 
-        try:
-            yield async_session
-        finally:
-            self._cached_session = None
-            self._session_id = None
+        yield async_session
 
-            async_session.expire_all()
-            await trans.rollback()
-            await async_session.close()
-            await connection.close()
+        self._cached_session = None
+        self._session_id = None
+
+        async_session.expire_all()
+        await trans.rollback()
+        await async_session.close()
+        await connection.close()
 
     @provide(scope=Scope.SESSION)
     async def get_ldap_session(

--- a/tests/search_request_datasets.py
+++ b/tests/search_request_datasets.py
@@ -50,7 +50,6 @@ test_search_by_rule_bit_and_dataset = [
     {
         "filter": f"(useraccountcontrol:1.2.840.113556.1.4.803:={UserAccountControlFlag.NORMAL_ACCOUNT})",  # noqa: E501
         "objects": [
-            "cn=System Administrator,dc=md,dc=test",
             "cn=user0,cn=users,dc=md,dc=test",
             "cn=user_admin,cn=users,dc=md,dc=test",
             "cn=user_admin_for_roles,cn=users,dc=md,dc=test",
@@ -84,7 +83,6 @@ test_search_by_rule_bit_and_dataset = [
     {
         "filter": f"(!(userAccountControl:1.2.840.113556.1.4.803:={UserAccountControlFlag.ACCOUNTDISABLE}))",  # noqa: E501
         "objects": [
-            "cn=System Administrator,dc=md,dc=test",
             "cn=user0,cn=users,dc=md,dc=test",
             "cn=user_admin,cn=users,dc=md,dc=test",
             "cn=user_admin_for_roles,cn=users,dc=md,dc=test",
@@ -106,7 +104,6 @@ test_search_by_rule_bit_or_dataset = [
             + UserAccountControlFlag.NORMAL_ACCOUNT
         })",
         "objects": [
-            "cn=System Administrator,dc=md,dc=test",
             "cn=user0,cn=users,dc=md,dc=test",
             "cn=user_admin,cn=users,dc=md,dc=test",
             "cn=user_admin_for_roles,cn=users,dc=md,dc=test",
@@ -127,7 +124,6 @@ test_search_by_rule_bit_or_dataset = [
     {
         "filter": f"(!(userAccountControl:1.2.840.113556.1.4.804:={UserAccountControlFlag.ACCOUNTDISABLE}))",  # noqa: E501
         "objects": [
-            "cn=System Administrator,dc=md,dc=test",
             "cn=user0,cn=users,dc=md,dc=test",
             "cn=user_admin,cn=users,dc=md,dc=test",
             "cn=user_admin_for_roles,cn=users,dc=md,dc=test",

--- a/tests/test_api/test_main/test_router/conftest.py
+++ b/tests/test_api/test_main/test_router/conftest.py
@@ -1,0 +1,49 @@
+"""Test main config.
+
+Copyright (c) 2024 MultiFactor
+License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
+"""
+
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ldap_protocol.auth.setup_gateway import SetupGateway
+from ldap_protocol.ldap_schema.attribute_value_validator import (
+    AttributeValueValidator,
+)
+from ldap_protocol.ldap_schema.entity_type_dao import EntityTypeDAO
+from ldap_protocol.ldap_schema.object_class_dao import ObjectClassDAO
+from ldap_protocol.utils.queries import get_base_directories
+from password_utils import PasswordUtils
+from tests.constants import TEST_SYSTEM_ADMIN_DATA
+
+
+@pytest_asyncio.fixture(scope="function")
+async def add_system_administrator(
+    session: AsyncSession,
+    password_utils: PasswordUtils,
+    setup_session: None,  # noqa: ARG001
+) -> None:
+    """Get session and acquire after completion."""
+    object_class_dao = ObjectClassDAO(session)
+    attribute_value_validator = AttributeValueValidator()
+    entity_type_dao = EntityTypeDAO(
+        session,
+        object_class_dao=object_class_dao,
+        attribute_value_validator=attribute_value_validator,
+    )
+
+    setup_gateway = SetupGateway(
+        session,
+        password_utils,
+        entity_type_dao,
+        attribute_value_validator=attribute_value_validator,
+    )
+
+    domain = (await get_base_directories(session))[0]
+    await setup_gateway.create_dir(
+        data=TEST_SYSTEM_ADMIN_DATA,
+        is_system=True,
+        domain=domain,
+        parent=domain,
+    )

--- a/tests/test_api/test_main/test_router/conftest.py
+++ b/tests/test_api/test_main/test_router/conftest.py
@@ -1,6 +1,6 @@
-"""Test main config.
+"""Test router config.
 
-Copyright (c) 2024 MultiFactor
+Copyright (c) 2026 MultiFactor
 License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 """
 
@@ -24,7 +24,7 @@ async def add_system_administrator(
     password_utils: PasswordUtils,
     setup_session: None,  # noqa: ARG001
 ) -> None:
-    """Get session and acquire after completion."""
+    """Create system administrator user for tests that require it."""
     object_class_dao = ObjectClassDAO(session)
     attribute_value_validator = AttributeValueValidator()
     entity_type_dao = EntityTypeDAO(

--- a/tests/test_api/test_main/test_router/test_delete.py
+++ b/tests/test_api/test_main/test_router/test_delete.py
@@ -31,6 +31,7 @@ async def test_api_correct_delete(http_client: AsyncClient) -> None:
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("setup_session")
 @pytest.mark.usefixtures("session")
+@pytest.mark.usefixtures("add_system_administrator")
 async def test_api_cant_delete_system_directory(
     http_client: AsyncClient,
 ) -> None:

--- a/tests/test_api/test_main/test_router/test_modify.py
+++ b/tests/test_api/test_main/test_router/test_modify.py
@@ -256,35 +256,6 @@ async def test_api_modify_non_exist_object(http_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("session")
-@pytest.mark.usefixtures("add_system_administrator")
-async def test_api_cant_modify_system_directory(
-    http_client: AsyncClient,
-) -> None:
-    """Test API for modify system directory."""
-    response = await http_client.patch(
-        "/entry/update",
-        json={
-            "object": "cn=System Administrator,dc=md,dc=test",
-            "changes": [
-                {
-                    "operation": Operation.REPLACE,
-                    "modification": {
-                        "type": "name",
-                        "vals": ["new_test"],
-                    },
-                },
-            ],
-        },
-    )
-
-    data = response.json()
-
-    assert isinstance(data, dict)
-    assert data.get("resultCode") == LDAPCodes.UNWILLING_TO_PERFORM
-
-
-@pytest.mark.asyncio
 @pytest.mark.usefixtures("setup_session")
 @pytest.mark.usefixtures("session")
 async def test_api_correct_modify_replace_memberof(

--- a/tests/test_api/test_main/test_router/test_modify.py
+++ b/tests/test_api/test_main/test_router/test_modify.py
@@ -257,6 +257,7 @@ async def test_api_modify_non_exist_object(http_client: AsyncClient) -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("session")
+@pytest.mark.usefixtures("add_system_administrator")
 async def test_api_cant_modify_system_directory(
     http_client: AsyncClient,
 ) -> None:

--- a/tests/test_api/test_main/test_router/test_modify_dn.py
+++ b/tests/test_api/test_main/test_router/test_modify_dn.py
@@ -456,6 +456,7 @@ async def test_api_update_dn_non_exist_superior(
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("setup_session")
 @pytest.mark.usefixtures("session")
+@pytest.mark.usefixtures("add_system_administrator")
 async def test_api_cant_update_system_directory(
     http_client: AsyncClient,
 ) -> None:

--- a/tests/test_api/test_main/test_router/test_search.py
+++ b/tests/test_api/test_main/test_router/test_search.py
@@ -96,7 +96,6 @@ async def test_api_search(http_client: AsyncClient) -> None:
     assert response["resultCode"] == LDAPCodes.SUCCESS
 
     sub_dirs = {
-        "cn=System Administrator,dc=md,dc=test",
         "cn=groups,dc=md,dc=test",
         "cn=users,dc=md,dc=test",
         "ou=testModifyDn1,dc=md,dc=test",
@@ -281,7 +280,6 @@ async def test_api_search_recursive_memberof(http_client: AsyncClient) -> None:
     """Test api search."""
     group = "cn=domain admins,cn=groups,dc=md,dc=test"
     members = [
-        "cn=System Administrator,dc=md,dc=test",
         "cn=developers,cn=groups,dc=md,dc=test",
         "cn=user0,cn=users,dc=md,dc=test",
         "cn=user_admin,cn=users,dc=md,dc=test",

--- a/tests/test_ldap/test_roles/test_search.py
+++ b/tests/test_ldap/test_roles/test_search.py
@@ -102,7 +102,6 @@ async def test_role_search_3(
         creds=creds,
         search_base=BASE_DN,
         expected_dn=[
-            "dn: cn=System Administrator,dc=md,dc=test",
             "dn: cn=groups,dc=md,dc=test",
             "dn: cn=users,dc=md,dc=test",
             "dn: cn=user_non_admin,cn=users,dc=md,dc=test",
@@ -190,7 +189,6 @@ async def test_role_search_5(
         creds=creds,
         search_base=BASE_DN,
         expected_dn=[
-            "dn: cn=System Administrator,dc=md,dc=test",
             "dn: cn=user1,cn=moscow,cn=russia,cn=users,dc=md,dc=test",
             "dn: cn=user_non_admin,cn=users,dc=md,dc=test",
             "dn: cn=user_admin_for_roles,cn=users,dc=md,dc=test",


### PR DESCRIPTION
Минорный рефакторинг для порядка:
- Перенес структуру тестов из Э;
- Заглушил "мусорные" CoverageWarning при запуске тестов.

Fix:
- Разрешил изменение системных директорий (запрет остался только на удаление и modify_dn).