### PR TITLE
Add: tmpfs and volume prune and kadmin_api depends on kdc

### DIFF
--- a/.package/docker-compose.yml
+++ b/.package/docker-compose.yml
@@ -316,6 +316,8 @@ services:
         condition: service_healthy
       cert_check:
         condition: service_completed_successfully
+      kdc:
+        condition: service_started
     working_dir: /server
     command: ./entrypoint.sh
   kadmind:

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ downgrade:  ## re-run migration
 down:  ## shutdown services
 	docker compose -f docker-compose.test.yml down --remove-orphans
 	docker compose down --remove-orphans
+	docker volume prune -f
 
 # server stage/development commands
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -34,12 +34,16 @@ services:
       - "5432"
     logging:
       driver: "none"
+    tmpfs:
+      - /var/lib/postgresql/data
 
   dragonfly:
     image: 'docker.dragonflydb.io/dragonflydb/dragonfly'
     container_name: dragonfly-test
     expose:
       - "6379"
+    tmpfs:
+      - /data
     deploy:
       resources:
         limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -284,6 +284,8 @@ services:
         restart: true
       cert_check:
         condition: service_completed_successfully
+      kdc:
+        condition: service_started
     ports:
       - 8000:8000
     working_dir: /server


### PR DESCRIPTION
- tmpfs: чтобы не хранить данные после запуска тестов
- volume prune: чтобы очищать volume от неименованных контейнеров
- kadmin_api depends on kdc: оба этих контейнера создают одну папку, из-за чего возникал race_condition, теперь нет