### PR TITLE
Fix ModifyDN access check

### DIFF
--- a/app/ldap_protocol/ldap_requests/delete.py
+++ b/app/ldap_protocol/ldap_requests/delete.py
@@ -74,6 +74,7 @@ class DeleteRequest(BaseRequest):
             select(Directory)
             .options(
                 joinedload(qa(Directory.user)),
+                joinedload(qa(Directory.entity_type)),
                 selectinload(qa(Directory.groups)).selectinload(
                     qa(Group.directory),
                 ),

--- a/app/ldap_protocol/ldap_requests/modify_dn.py
+++ b/app/ldap_protocol/ldap_requests/modify_dn.py
@@ -6,9 +6,9 @@ License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 
 from typing import AsyncGenerator, ClassVar
 
-from loguru import logger
 from sqlalchemy import delete, func, select, text, update
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 
 from entities import AccessControlEntry, Attribute, Directory
@@ -25,6 +25,7 @@ from ldap_protocol.objects import (
     PartialAttribute,
     ProtocolRequests,
 )
+from ldap_protocol.roles.access_manager import AccessManager
 from ldap_protocol.utils.queries import get_filter_from_path, validate_entry
 from repo.pg.tables import (
     ace_directory_memberships_table,
@@ -91,15 +92,81 @@ class ModifyDNRequest(BaseRequest):
             new_superior=None if len(data) < 4 else data[3].value,
         )
 
-    def is_move_to_new_superior(self, directory: Directory) -> bool:
-        """Check if the request is a move operation."""
+    def _is_move_to_new_superior(self, directory: Directory) -> bool:
         return bool(
             self.new_superior
             and directory.parent
             and self.new_superior != directory.parent.path_dn,
         )
 
-    async def handle(
+    def _can_rename(
+        self,
+        access_manager: AccessManager,
+        directory: Directory,
+        name: str,
+    ) -> bool:
+        return access_manager.check_modify_access(
+            changes=[
+                Changes(
+                    operation=Operation.REPLACE,
+                    modification=PartialAttribute(type="name", vals=[name]),
+                ),
+            ],
+            aces=directory.access_control_entries,
+            entity_type_id=directory.entity_type_id,
+        )
+
+    async def _delete_old_inherited_aces(
+        self,
+        session: AsyncSession,
+        directory_id: int,
+        old_depth: int,
+    ) -> None:
+        old_inherited_aces_query = (
+            select(qa(AccessControlEntry.id))
+            .options(selectinload(qa(AccessControlEntry.directories)))
+            .where(
+                qa(AccessControlEntry.directories).any(
+                    qa(Directory.id) == directory_id,
+                ),
+                qa(AccessControlEntry.depth) != old_depth,
+            )
+        )
+        await session.execute(
+            delete(ace_directory_memberships_table)
+            .filter_by(
+                directory_id=directory_id,
+            )
+            .where(
+                ace_directory_memberships_table.c.access_control_entry_id.in_(
+                    old_inherited_aces_query,
+                ),
+            ),
+        )
+
+    async def _update_explicit_aces(
+        self,
+        session: AsyncSession,
+        directory: Directory,
+        old_depth: int,
+    ) -> None:
+        explicit_aces_query = (
+            select(AccessControlEntry)
+            .options(selectinload(qa(AccessControlEntry.directories)))
+            .where(
+                qa(AccessControlEntry.directories).any(
+                    qa(Directory.id) == directory.id,
+                ),
+                qa(AccessControlEntry.depth) == old_depth,
+            )
+        )
+        for ace in await session.scalars(explicit_aces_query):
+            ace.directories.append(directory)
+            ace.path = directory.path_dn
+            ace.depth = directory.depth
+
+
+    async def handle(  # noqa: C901
         self,
         ctx: LDAPModifyDNRequestContext,
     ) -> AsyncGenerator[ModifyDNResponse, None]:
@@ -156,8 +223,20 @@ class ModifyDNRequest(BaseRequest):
             )
             return
 
-        old_name = directory.name
         new_dn, new_name = self.newrdn.split("=")
+        is_move_to_new_superior = self._is_move_to_new_superior(directory)
+
+        if not is_move_to_new_superior and not self._can_rename(
+            ctx.access_manager,
+            directory,
+            new_name,
+        ):
+            yield ModifyDNResponse(
+                result_code=LDAPCodes.INSUFFICIENT_ACCESS_RIGHTS,
+            )
+            return
+
+        old_name = directory.name
         directory.name = new_name
 
         old_path = directory.path
@@ -180,9 +259,28 @@ class ModifyDNRequest(BaseRequest):
             )
             return
 
-        if self.is_move_to_new_superior(directory) and self.new_superior:
+        if is_move_to_new_superior:
+            delete_aces = [
+                ace for ace in directory.access_control_entries
+                if (
+                    ace.ace_type == AceType.DELETE
+                    and ace.attribute_type is None
+                )
+            ]
+
+            can_delete = ctx.access_manager.check_entity_level_access(
+                aces=delete_aces,
+                entity_type_id=directory.entity_type_id,
+            )
+
+            if not can_delete:
+                yield ModifyDNResponse(
+                    result_code=LDAPCodes.INSUFFICIENT_ACCESS_RIGHTS,
+                )
+                return
+
             new_sup_query = select(Directory).filter(
-                get_filter_from_path(self.new_superior),
+                get_filter_from_path(self.new_superior),  # type: ignore
             )
             new_sup_query = ctx.access_manager.mutate_query_with_ace_load(
                 user_role_ids=ctx.ldap_session.user.role_ids,
@@ -213,11 +311,11 @@ class ModifyDNRequest(BaseRequest):
 
             try:
                 await ctx.session.flush()
-                await ctx.session.execute(
-                    delete(ace_directory_memberships_table)
-                    .filter_by(directory_id=directory.id),
-                )  # fmt: skip
-
+                await self._delete_old_inherited_aces(
+                    ctx.session,
+                    directory_id=directory.id,
+                    old_depth=old_depth,
+                )
                 await ctx.role_use_case.inherit_parent_aces(
                     parent_directory=directory.parent,
                     directory=directory,
@@ -229,27 +327,6 @@ class ModifyDNRequest(BaseRequest):
                     result_code=LDAPCodes.ENTRY_ALREADY_EXISTS,
                 )
                 return
-        else:
-            can_modify = ctx.access_manager.check_modify_access(
-                changes=[
-                    Changes(
-                        operation=Operation.DELETE,
-                        modification=PartialAttribute(type="cn", vals="value"),
-                    ),
-                ],
-                aces=directory.access_control_entries,
-                entity_type_id=directory.entity_type_id,
-            )
-            logger.critical(f"Can modify: {can_modify}")
-            if not can_modify:
-                yield ModifyDNResponse(
-                    result_code=LDAPCodes.INSUFFICIENT_ACCESS_RIGHTS,
-                )
-                return
-
-        logger.critical(self.entry)
-        logger.critical(self.newrdn)
-        logger.critical(self.new_superior)
 
         async with ctx.session.begin_nested():
             if self.deleteoldrdn:
@@ -296,20 +373,15 @@ class ModifyDNRequest(BaseRequest):
                 )
                 await ctx.session.flush()
 
-                explicit_aces_query = (
-                    select(AccessControlEntry)
-                    .options(selectinload(qa(AccessControlEntry.directories)))
-                    .where(
-                        qa(AccessControlEntry.directories).any(
-                            qa(Directory.id) == directory.id,
-                        ),
-                        qa(AccessControlEntry.depth) == old_depth,
-                    )
+                new_depth = old_depth
+                if is_move_to_new_superior:
+                    new_depth = directory.depth
+
+                await self._update_explicit_aces(
+                    ctx.session,
+                    directory,
+                    new_depth,
                 )
-                for ace in await ctx.session.scalars(explicit_aces_query):
-                    ace.directories.append(directory)
-                    ace.path = directory.path_dn
-                    ace.depth = directory.depth
 
             await ctx.session.flush()
 

--- a/app/ldap_protocol/ldap_requests/modify_dn.py
+++ b/app/ldap_protocol/ldap_requests/modify_dn.py
@@ -99,19 +99,32 @@ class ModifyDNRequest(BaseRequest):
             and self.new_superior != directory.parent.path_dn,
         )
 
-    def _can_rename(
+    def _can_modify_rdn(
         self,
         access_manager: AccessManager,
         directory: Directory,
-        name: str,
+        old_dn: str,
+        old_name: str,
+        new_dn: str,
+        new_name: str,
     ) -> bool:
-        return access_manager.check_modify_access(
-            changes=[
+        change = [
+            Changes(
+                operation=Operation.ADD,
+                modification=PartialAttribute(type=new_dn, vals=[new_name]),
+            ),
+        ]
+        if self.deleteoldrdn:
+            change.append(
                 Changes(
-                    operation=Operation.REPLACE,
-                    modification=PartialAttribute(type="name", vals=[name]),
+                    operation=Operation.DELETE,
+                    modification=PartialAttribute(
+                        type=old_dn, vals=[old_name],
+                    ),
                 ),
-            ],
+            )
+        return access_manager.check_modify_access(
+            changes=change,
             aces=directory.access_control_entries,
             entity_type_id=directory.entity_type_id,
         )
@@ -218,10 +231,18 @@ class ModifyDNRequest(BaseRequest):
         new_dn, new_name = self.newrdn.split("=")
         is_move_to_new_superior = self._is_move_to_new_superior(directory)
 
-        if not is_move_to_new_superior and not self._can_rename(
-            ctx.access_manager,
-            directory,
-            new_name,
+        old_name = directory.name
+        old_path = directory.path
+        old_dn = old_path[-1].split("=")[0]
+        old_depth = directory.depth
+
+        if not self._can_modify_rdn(
+            access_manager=ctx.access_manager,
+            directory=directory,
+            old_dn=old_dn,
+            old_name=old_name,
+            new_dn=new_dn,
+            new_name=new_name,
         ):
             yield ModifyDNResponse(
                 result_code=LDAPCodes.INSUFFICIENT_ACCESS_RIGHTS,
@@ -243,12 +264,7 @@ class ModifyDNRequest(BaseRequest):
             )
             return
 
-        old_name = directory.name
         directory.name = new_name
-
-        old_path = directory.path
-        old_dn = old_path[-1].split("=")[0]
-        old_depth = directory.depth
 
         if is_move_to_new_superior:
             delete_aces = [

--- a/app/ldap_protocol/ldap_requests/modify_dn.py
+++ b/app/ldap_protocol/ldap_requests/modify_dn.py
@@ -119,23 +119,21 @@ class ModifyDNRequest(BaseRequest):
     async def _delete_old_inherited_aces(
         self,
         session: AsyncSession,
-        directory_id: int,
+        directory: Directory,
         old_depth: int,
     ) -> None:
         old_inherited_aces_query = (
             select(qa(AccessControlEntry.id))
             .options(selectinload(qa(AccessControlEntry.directories)))
             .where(
-                qa(AccessControlEntry.directories).any(
-                    qa(Directory.id) == directory_id,
-                ),
+                qa(AccessControlEntry.directories).contains(directory),
                 qa(AccessControlEntry.depth) != old_depth,
             )
         )
         await session.execute(
             delete(ace_directory_memberships_table)
             .filter_by(
-                directory_id=directory_id,
+                directory_id=directory.id,
             )
             .where(
                 ace_directory_memberships_table.c.access_control_entry_id.in_(
@@ -154,17 +152,13 @@ class ModifyDNRequest(BaseRequest):
             select(AccessControlEntry)
             .options(selectinload(qa(AccessControlEntry.directories)))
             .where(
-                qa(AccessControlEntry.directories).any(
-                    qa(Directory.id) == directory.id,
-                ),
+                qa(AccessControlEntry.directories).contains(directory),
                 qa(AccessControlEntry.depth) == old_depth,
             )
         )
         for ace in await session.scalars(explicit_aces_query):
-            ace.directories.append(directory)
             ace.path = directory.path_dn
             ace.depth = directory.depth
-
 
     async def handle(  # noqa: C901
         self,
@@ -261,7 +255,8 @@ class ModifyDNRequest(BaseRequest):
 
         if is_move_to_new_superior:
             delete_aces = [
-                ace for ace in directory.access_control_entries
+                ace
+                for ace in directory.access_control_entries
                 if (
                     ace.ace_type == AceType.DELETE
                     and ace.attribute_type is None
@@ -313,7 +308,7 @@ class ModifyDNRequest(BaseRequest):
                 await ctx.session.flush()
                 await self._delete_old_inherited_aces(
                     ctx.session,
-                    directory_id=directory.id,
+                    directory=directory,
                     old_depth=old_depth,
                 )
                 await ctx.role_use_case.inherit_parent_aces(
@@ -373,14 +368,10 @@ class ModifyDNRequest(BaseRequest):
                 )
                 await ctx.session.flush()
 
-                new_depth = old_depth
-                if is_move_to_new_superior:
-                    new_depth = directory.depth
-
                 await self._update_explicit_aces(
                     ctx.session,
                     directory,
-                    new_depth,
+                    old_depth,
                 )
 
             await ctx.session.flush()

--- a/app/ldap_protocol/ldap_requests/modify_dn.py
+++ b/app/ldap_protocol/ldap_requests/modify_dn.py
@@ -19,7 +19,12 @@ from ldap_protocol.ldap_responses import (
     INVALID_ACCESS_RESPONSE,
     ModifyDNResponse,
 )
-from ldap_protocol.objects import ProtocolRequests
+from ldap_protocol.objects import (
+    Changes,
+    Operation,
+    PartialAttribute,
+    ProtocolRequests,
+)
 from ldap_protocol.utils.queries import get_filter_from_path, validate_entry
 from repo.pg.tables import (
     ace_directory_memberships_table,
@@ -131,8 +136,8 @@ class ModifyDNRequest(BaseRequest):
         query = ctx.access_manager.mutate_query_with_ace_load(
             user_role_ids=ctx.ldap_session.user.role_ids,
             query=query,
-            ace_types=[AceType.DELETE],
-            require_attribute_type_null=True,
+            ace_types=[AceType.DELETE, AceType.WRITE],
+            load_attribute_type=True,
         )
 
         directory = await ctx.session.scalar(query)
@@ -222,6 +227,23 @@ class ModifyDNRequest(BaseRequest):
                 await ctx.session.rollback()
                 yield ModifyDNResponse(
                     result_code=LDAPCodes.ENTRY_ALREADY_EXISTS,
+                )
+                return
+        else:
+            can_modify = ctx.access_manager.check_modify_access(
+                changes=[
+                    Changes(
+                        operation=Operation.DELETE,
+                        modification=PartialAttribute(type="cn", vals="value"),
+                    ),
+                ],
+                aces=directory.access_control_entries,
+                entity_type_id=directory.entity_type_id,
+            )
+            logger.critical(f"Can modify: {can_modify}")
+            if not can_modify:
+                yield ModifyDNResponse(
+                    result_code=LDAPCodes.INSUFFICIENT_ACCESS_RIGHTS,
                 )
                 return
 

--- a/app/ldap_protocol/ldap_requests/modify_dn.py
+++ b/app/ldap_protocol/ldap_requests/modify_dn.py
@@ -9,7 +9,7 @@ from typing import AsyncGenerator, ClassVar
 from sqlalchemy import delete, func, select, text, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload, selectinload
+from sqlalchemy.orm import joinedload
 
 from entities import AccessControlEntry, Attribute, Directory
 from enums import AceType
@@ -122,9 +122,8 @@ class ModifyDNRequest(BaseRequest):
         directory: Directory,
         old_depth: int,
     ) -> None:
-        old_inherited_aces_query = (
+        old_inherited_aces_ids = (
             select(qa(AccessControlEntry.id))
-            .options(selectinload(qa(AccessControlEntry.directories)))
             .where(
                 qa(AccessControlEntry.directories).contains(directory),
                 qa(AccessControlEntry.depth) != old_depth,
@@ -137,7 +136,7 @@ class ModifyDNRequest(BaseRequest):
             )
             .where(
                 ace_directory_memberships_table.c.access_control_entry_id.in_(
-                    old_inherited_aces_query,
+                    old_inherited_aces_ids,
                 ),
             ),
         )
@@ -148,17 +147,19 @@ class ModifyDNRequest(BaseRequest):
         directory: Directory,
         old_depth: int,
     ) -> None:
-        explicit_aces_query = (
-            select(AccessControlEntry)
-            .options(selectinload(qa(AccessControlEntry.directories)))
+        explicit_aces_ids = (
+            select(qa(AccessControlEntry.id))
             .where(
                 qa(AccessControlEntry.directories).contains(directory),
                 qa(AccessControlEntry.depth) == old_depth,
             )
         )
-        for ace in await session.scalars(explicit_aces_query):
-            ace.path = directory.path_dn
-            ace.depth = directory.depth
+        await session.execute(
+            update(AccessControlEntry)
+            .where(qa(AccessControlEntry.id).in_(explicit_aces_ids))
+            .values(path=directory.path_dn, depth=directory.depth)
+            .execution_options(synchronize_session=False),
+        )
 
     async def handle(  # noqa: C901
         self,
@@ -230,14 +231,6 @@ class ModifyDNRequest(BaseRequest):
             )
             return
 
-        old_name = directory.name
-        directory.name = new_name
-
-        old_path = directory.path
-        old_dn = old_path[-1].split("=")[0]
-
-        old_depth = directory.depth
-
         if (
             directory.entity_type
             and not ctx.attribute_value_validator.is_value_valid(
@@ -252,6 +245,13 @@ class ModifyDNRequest(BaseRequest):
                 message="Invalid attribute value(s)",
             )
             return
+
+        old_name = directory.name
+        directory.name = new_name
+
+        old_path = directory.path
+        old_dn = old_path[-1].split("=")[0]
+        old_depth = directory.depth
 
         if is_move_to_new_superior:
             delete_aces = [

--- a/app/ldap_protocol/ldap_requests/modify_dn.py
+++ b/app/ldap_protocol/ldap_requests/modify_dn.py
@@ -6,6 +6,7 @@ License: https://github.com/MultiDirectoryLab/MultiDirectory/blob/main/LICENSE
 
 from typing import AsyncGenerator, ClassVar
 
+from loguru import logger
 from sqlalchemy import delete, func, select, text, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload, selectinload
@@ -83,6 +84,14 @@ class ModifyDNRequest(BaseRequest):
             newrdn=data[1].value,
             deleteoldrdn=data[2].value,
             new_superior=None if len(data) < 4 else data[3].value,
+        )
+
+    def is_move_to_new_superior(self, directory: Directory) -> bool:
+        """Check if the request is a move operation."""
+        return bool(
+            self.new_superior
+            and directory.parent
+            and self.new_superior != directory.parent.path_dn,
         )
 
     async def handle(
@@ -166,11 +175,7 @@ class ModifyDNRequest(BaseRequest):
             )
             return
 
-        if (
-            self.new_superior
-            and directory.parent
-            and self.new_superior != directory.parent.path_dn
-        ):
+        if self.is_move_to_new_superior(directory) and self.new_superior:
             new_sup_query = select(Directory).filter(
                 get_filter_from_path(self.new_superior),
             )
@@ -219,6 +224,10 @@ class ModifyDNRequest(BaseRequest):
                     result_code=LDAPCodes.ENTRY_ALREADY_EXISTS,
                 )
                 return
+
+        logger.critical(self.entry)
+        logger.critical(self.newrdn)
+        logger.critical(self.new_superior)
 
         async with ctx.session.begin_nested():
             if self.deleteoldrdn:

--- a/app/ldap_protocol/ldap_requests/modify_dn.py
+++ b/app/ldap_protocol/ldap_requests/modify_dn.py
@@ -119,7 +119,8 @@ class ModifyDNRequest(BaseRequest):
                 Changes(
                     operation=Operation.DELETE,
                     modification=PartialAttribute(
-                        type=old_dn, vals=[old_name],
+                        type=old_dn,
+                        vals=[old_name],
                     ),
                 ),
             )

--- a/app/ldap_protocol/ldap_requests/modify_dn.py
+++ b/app/ldap_protocol/ldap_requests/modify_dn.py
@@ -122,12 +122,9 @@ class ModifyDNRequest(BaseRequest):
         directory: Directory,
         old_depth: int,
     ) -> None:
-        old_inherited_aces_ids = (
-            select(qa(AccessControlEntry.id))
-            .where(
-                qa(AccessControlEntry.directories).contains(directory),
-                qa(AccessControlEntry.depth) != old_depth,
-            )
+        old_inherited_aces_ids = select(qa(AccessControlEntry.id)).where(
+            qa(AccessControlEntry.directories).contains(directory),
+            qa(AccessControlEntry.depth) != old_depth,
         )
         await session.execute(
             delete(ace_directory_memberships_table)
@@ -146,19 +143,19 @@ class ModifyDNRequest(BaseRequest):
         session: AsyncSession,
         directory: Directory,
         old_depth: int,
+        new_path: list[str],
     ) -> None:
-        explicit_aces_ids = (
-            select(qa(AccessControlEntry.id))
-            .where(
-                qa(AccessControlEntry.directories).contains(directory),
-                qa(AccessControlEntry.depth) == old_depth,
-            )
+        new_path_dn = ",".join(reversed(new_path))
+        new_depth = len(new_path)
+
+        explicit_aces_ids = select(qa(AccessControlEntry.id)).where(
+            qa(AccessControlEntry.directories).contains(directory),
+            qa(AccessControlEntry.depth) == old_depth,
         )
         await session.execute(
             update(AccessControlEntry)
             .where(qa(AccessControlEntry.id).in_(explicit_aces_ids))
-            .values(path=directory.path_dn, depth=directory.depth)
-            .execution_options(synchronize_session=False),
+            .values(path=new_path_dn, depth=new_depth),
         )
 
     async def handle(  # noqa: C901
@@ -372,6 +369,7 @@ class ModifyDNRequest(BaseRequest):
                     ctx.session,
                     directory,
                     old_depth,
+                    new_path,
                 )
 
             await ctx.session.flush()

--- a/app/ldap_protocol/roles/access_manager.py
+++ b/app/ldap_protocol/roles/access_manager.py
@@ -304,12 +304,19 @@ class AccessManager:
             null attribute_type_id
         :return: mutated query with access control entries loaded
         """
-        selectin_loader = selectinload(
+        base_loader = selectinload(
             qa(Directory.access_control_entries),
         )
+
+        loader_options = [
+            base_loader.joinedload(qa(AccessControlEntry.entity_type)),
+        ]
+
         if load_attribute_type:
-            selectin_loader = selectin_loader.joinedload(
-                qa(AccessControlEntry.attribute_type),
+            loader_options.append(
+                base_loader.joinedload(
+                    qa(AccessControlEntry.attribute_type),
+                ),
             )
 
         criteria_conditions = [
@@ -331,7 +338,7 @@ class AccessManager:
             )
 
         return query.options(
-            selectin_loader,
+            *loader_options,
             with_loader_criteria(
                 AccessControlEntry,
                 and_(*criteria_conditions),

--- a/tests/test_ldap/test_util/test_modify.py
+++ b/tests/test_ldap/test_util/test_modify.py
@@ -18,9 +18,10 @@ from sqlalchemy.orm import joinedload, selectinload, subqueryload
 
 from config import Settings
 from entities import Directory, Group
-from enums import AceType, RoleScope
+from enums import AceType, EntityTypeNames, RoleScope
 from ldap_protocol.kerberos.base import AbstractKadmin
 from ldap_protocol.ldap_codes import LDAPCodes
+from ldap_protocol.ldap_schema.entity_type_dao import EntityTypeDAO
 from ldap_protocol.objects import Operation
 from ldap_protocol.roles.ace_dao import AccessControlEntryDAO
 from ldap_protocol.roles.dataclasses import AccessControlEntryDTO, RoleDTO
@@ -997,3 +998,256 @@ async def test_ldap_modify_replace_memberof_primary_group_various(
     user_dir = await fetch_directory_by_dn(session, user_dn)
     group_names = {group.directory.name for group in user_dir.groups}
     assert group_names == expected_groups
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("setup_session")
+async def test_modify_dn_rename_with_ap(
+    settings: Settings,
+    creds: TestCreds,
+    role_dao: RoleDAO,
+    access_control_entry_dao: AccessControlEntryDAO,
+    entity_type_dao: EntityTypeDAO,
+    attribute_type_dao: EntityTypeDAO,
+) -> None:
+    dn = "cn=user0,cn=Users,dc=md,dc=test"
+    base_dn = "dc=md,dc=test"
+
+    user_entity_type = await entity_type_dao.get(EntityTypeNames.USER)
+    assert user_entity_type
+
+    name_attr = await attribute_type_dao.get("name")
+    assert name_attr
+
+    async def try_modify() -> int:
+        with tempfile.NamedTemporaryFile("w") as file:
+            file.write(
+                (
+                    f"dn: {dn}\n"
+                    "changetype: modrdn\n"
+                    "newrdn: cn=user2\n"
+                    "deleteoldrdn: 1\n"
+                ),
+            )
+            file.seek(0)
+            proc = await asyncio.create_subprocess_exec(
+                "ldapmodify",
+                "-vvv",
+                "-H",
+                f"ldap://{settings.HOST}:{settings.PORT}",
+                "-D",
+                "user_non_admin",
+                "-x",
+                "-w",
+                creds.pw,
+                "-f",
+                file.name,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+
+            await proc.communicate()
+            return await proc.wait()
+
+    assert await try_modify() == LDAPCodes.INSUFFICIENT_ACCESS_RIGHTS
+
+    await role_dao.create(
+        dto=RoleDTO(
+            name="Modify Role",
+            creator_upn=None,
+            is_system=False,
+            groups=["cn=domain users,cn=Groups," + base_dn],
+        ),
+    )
+
+    role_id = role_dao.get_last_id()
+
+    write_ace = AccessControlEntryDTO(
+        role_id=role_id,
+        ace_type=AceType.WRITE,
+        scope=RoleScope.WHOLE_SUBTREE,
+        base_dn=dn,
+        attribute_type_id=name_attr.id,
+        entity_type_id=user_entity_type.id,
+        is_allow=True,
+    )
+    delete_ace = AccessControlEntryDTO(
+        role_id=role_id,
+        ace_type=AceType.DELETE,
+        scope=RoleScope.WHOLE_SUBTREE,
+        base_dn=dn,
+        attribute_type_id=name_attr.id,
+        entity_type_id=user_entity_type.id,
+        is_allow=True,
+    )
+
+    await access_control_entry_dao.create_bulk([write_ace, delete_ace])
+
+    aces_before = await access_control_entry_dao.get_all()
+
+    assert await try_modify() == LDAPCodes.SUCCESS
+
+    aces_after = await access_control_entry_dao.get_all()
+
+    inherited_aces_before = [
+        ace for ace in aces_before if ace.base_dn == base_dn
+    ]
+    explicit_aces_before = [
+        ace for ace in aces_before if ace.base_dn != base_dn
+    ]
+
+    inherited_aces_after = [
+        ace for ace in aces_after if ace.base_dn == base_dn
+    ]
+    explicit_aces_after = [ace for ace in aces_after if ace.base_dn != base_dn]
+
+    assert inherited_aces_before == inherited_aces_after
+    assert len(explicit_aces_after) == len(explicit_aces_before)
+
+    # check expicit aces have same properties except base_dn
+    for ace_before, ace_after in zip(
+        explicit_aces_before,
+        explicit_aces_after,
+    ):
+        assert ace_before.id == ace_after.id
+        assert ace_before.role_id == ace_after.role_id
+        assert ace_before.ace_type == ace_after.ace_type
+        assert ace_before.scope == ace_after.scope
+        assert ace_before.attribute_type_id == ace_after.attribute_type_id
+        assert ace_before.entity_type_id == ace_after.entity_type_id
+        assert ace_before.is_allow == ace_after.is_allow
+
+        assert ace_after.base_dn == "cn=user2,cn=Users,dc=md,dc=test"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("setup_session")
+async def test_modify_dn_move_with_ap(
+    settings: Settings,
+    creds: TestCreds,
+    role_dao: RoleDAO,
+    access_control_entry_dao: AccessControlEntryDAO,
+    entity_type_dao: EntityTypeDAO,
+    attribute_type_dao: EntityTypeDAO,
+) -> None:
+    dn = "cn=user0,cn=Users,dc=md,dc=test"
+    base_dn = "dc=md,dc=test"
+
+    user_entity_type = await entity_type_dao.get(EntityTypeNames.USER)
+    assert user_entity_type
+
+    name_attr = await attribute_type_dao.get("name")
+    assert name_attr
+
+    new_parent_dn = "cn=Groups,dc=md,dc=test"
+
+    async def try_modify() -> int:
+        with tempfile.NamedTemporaryFile("w") as file:
+            file.write(
+                (
+                    f"dn: {dn}\n"
+                    "changetype: modrdn\n"
+                    "newrdn: cn=user2\n"
+                    "deleteoldrdn: 1\n"
+                    f"newsuperior: {new_parent_dn}\n"
+                ),
+            )
+            file.seek(0)
+            proc = await asyncio.create_subprocess_exec(
+                "ldapmodify",
+                "-vvv",
+                "-H",
+                f"ldap://{settings.HOST}:{settings.PORT}",
+                "-D",
+                "user_non_admin",
+                "-x",
+                "-w",
+                creds.pw,
+                "-f",
+                file.name,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+
+            await proc.communicate()
+            return await proc.wait()
+
+    assert await try_modify() == LDAPCodes.INSUFFICIENT_ACCESS_RIGHTS
+
+    await role_dao.create(
+        dto=RoleDTO(
+            name="Modify Role",
+            creator_upn=None,
+            is_system=False,
+            groups=["cn=domain users,cn=Groups," + base_dn],
+        ),
+    )
+
+    role_id = role_dao.get_last_id()
+
+    create_ace = AccessControlEntryDTO(
+        role_id=role_id,
+        ace_type=AceType.CREATE_CHILD,
+        scope=RoleScope.WHOLE_SUBTREE,
+        base_dn=new_parent_dn,
+        attribute_type_id=None,
+        entity_type_id=user_entity_type.id,
+        is_allow=True,
+    )
+    delete_ace = AccessControlEntryDTO(
+        role_id=role_id,
+        ace_type=AceType.DELETE,
+        scope=RoleScope.WHOLE_SUBTREE,
+        base_dn=dn,
+        attribute_type_id=None,
+        entity_type_id=user_entity_type.id,
+        is_allow=True,
+    )
+
+    await access_control_entry_dao.create_bulk([create_ace, delete_ace])
+
+    aces_before = await access_control_entry_dao.get_all()
+
+    assert await try_modify() == LDAPCodes.SUCCESS
+
+    aces_after = await access_control_entry_dao.get_all()
+
+    inherited_aces_before = [
+        ace
+        for ace in aces_before
+        if ace.base_dn != "cn=user0,cn=Users,dc=md,dc=test"
+    ]
+    explicit_aces_before = [
+        ace
+        for ace in aces_before
+        if ace.base_dn == "cn=user0,cn=Users,dc=md,dc=test"
+    ]
+
+    inherited_aces_after = [
+        ace
+        for ace in aces_after
+        if ace.base_dn != "cn=user2,cn=Groups,dc=md,dc=test"
+    ]
+    explicit_aces_after = [
+        ace
+        for ace in aces_after
+        if ace.base_dn == "cn=user2,cn=Groups,dc=md,dc=test"
+    ]
+
+    assert inherited_aces_before == inherited_aces_after
+    assert len(explicit_aces_after) == len(explicit_aces_before)
+
+    # check expicit aces have same properties except base_dn
+    for ace_before, ace_after in zip(
+        explicit_aces_before,
+        explicit_aces_after,
+    ):
+        assert ace_before.id == ace_after.id
+        assert ace_before.role_id == ace_after.role_id
+        assert ace_before.ace_type == ace_after.ace_type
+        assert ace_before.scope == ace_after.scope
+        assert ace_before.attribute_type_id == ace_after.attribute_type_id
+        assert ace_before.entity_type_id == ace_after.entity_type_id
+        assert ace_before.is_allow == ace_after.is_allow
+
+        assert ace_after.base_dn == "cn=user2,cn=Groups,dc=md,dc=test"

--- a/tests/test_ldap/test_util/test_modify.py
+++ b/tests/test_ldap/test_util/test_modify.py
@@ -1059,8 +1059,8 @@ async def test_modify_dn_rename_with_ap(
     user_entity_type = await entity_type_dao.get(EntityTypeNames.USER)
     assert user_entity_type
 
-    name_attr = await attribute_type_dao.get("name")
-    assert name_attr
+    rdn_attr = await attribute_type_dao.get("cn")
+    assert rdn_attr
 
     res = await run_single_modrdn(
         settings=settings,
@@ -1089,7 +1089,7 @@ async def test_modify_dn_rename_with_ap(
         ace_type=AceType.WRITE,
         scope=RoleScope.WHOLE_SUBTREE,
         base_dn=dn,
-        attribute_type_id=name_attr.id,
+        attribute_type_id=rdn_attr.id,
         entity_type_id=user_entity_type.id,
         is_allow=True,
     )
@@ -1098,7 +1098,7 @@ async def test_modify_dn_rename_with_ap(
         ace_type=AceType.DELETE,
         scope=RoleScope.WHOLE_SUBTREE,
         base_dn=dn,
-        attribute_type_id=name_attr.id,
+        attribute_type_id=rdn_attr.id,
         entity_type_id=user_entity_type.id,
         is_allow=True,
     )
@@ -1167,8 +1167,8 @@ async def test_modify_dn_move_with_ap(
     user_entity_type = await entity_type_dao.get(EntityTypeNames.USER)
     assert user_entity_type
 
-    name_attr = await attribute_type_dao.get("name")
-    assert name_attr
+    rdn_attr = await attribute_type_dao.get("cn")
+    assert rdn_attr
 
     new_parent_dn = "cn=Groups,dc=md,dc=test"
 
@@ -1195,6 +1195,15 @@ async def test_modify_dn_move_with_ap(
 
     role_id = role_dao.get_last_id()
 
+    write_ace = AccessControlEntryDTO(
+        role_id=role_id,
+        ace_type=AceType.WRITE,
+        scope=RoleScope.WHOLE_SUBTREE,
+        base_dn=dn,
+        attribute_type_id=rdn_attr.id,
+        entity_type_id=user_entity_type.id,
+        is_allow=True,
+    )
     create_ace = AccessControlEntryDTO(
         role_id=role_id,
         ace_type=AceType.CREATE_CHILD,
@@ -1214,7 +1223,9 @@ async def test_modify_dn_move_with_ap(
         is_allow=True,
     )
 
-    await access_control_entry_dao.create_bulk([create_ace, delete_ace])
+    await access_control_entry_dao.create_bulk(
+        [write_ace, create_ace, delete_ace],
+    )
 
     aces_before = await access_control_entry_dao.get_all()
 

--- a/tests/test_ldap/test_util/test_modify.py
+++ b/tests/test_ldap/test_util/test_modify.py
@@ -822,6 +822,49 @@ async def run_single_modify(
         return await proc.wait()
 
 
+async def run_single_modrdn(
+    *,
+    settings: Settings,
+    bind_dn: str,
+    password: str,
+    dn: str,
+    newrdn: str,
+    deleteoldrdn: int = 1,
+    newsuperior: str | None = None,
+) -> int:
+    with tempfile.NamedTemporaryFile("w") as file:
+        lines = [
+            f"dn: {dn}",
+            "changetype: modrdn",
+            f"newrdn: {newrdn}",
+            f"deleteoldrdn: {deleteoldrdn}",
+        ]
+        if newsuperior is not None:
+            lines.append(f"newsuperior: {newsuperior}")
+
+        file.write("\n".join(lines) + "\n")
+        file.seek(0)
+
+        proc = await asyncio.create_subprocess_exec(
+            "ldapmodify",
+            "-vvv",
+            "-H",
+            f"ldap://{settings.HOST}:{settings.PORT}",
+            "-D",
+            bind_dn,
+            "-x",
+            "-w",
+            password,
+            "-f",
+            file.name,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        await proc.communicate()
+        return await proc.wait()
+
+
 async def fetch_directory_by_dn(session: AsyncSession, dn: str) -> Directory:
     """Fetch directory by DN."""
     query = (
@@ -1019,37 +1062,16 @@ async def test_modify_dn_rename_with_ap(
     name_attr = await attribute_type_dao.get("name")
     assert name_attr
 
-    async def try_modify() -> int:
-        with tempfile.NamedTemporaryFile("w") as file:
-            file.write(
-                (
-                    f"dn: {dn}\n"
-                    "changetype: modrdn\n"
-                    "newrdn: cn=user2\n"
-                    "deleteoldrdn: 1\n"
-                ),
-            )
-            file.seek(0)
-            proc = await asyncio.create_subprocess_exec(
-                "ldapmodify",
-                "-vvv",
-                "-H",
-                f"ldap://{settings.HOST}:{settings.PORT}",
-                "-D",
-                "user_non_admin",
-                "-x",
-                "-w",
-                creds.pw,
-                "-f",
-                file.name,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
+    res = await run_single_modrdn(
+        settings=settings,
+        bind_dn="user_non_admin",
+        password=creds.pw,
+        dn=dn,
+        newrdn="cn=user2",
+        deleteoldrdn=1,
+    )
 
-            await proc.communicate()
-            return await proc.wait()
-
-    assert await try_modify() == LDAPCodes.INSUFFICIENT_ACCESS_RIGHTS
+    assert res == LDAPCodes.INSUFFICIENT_ACCESS_RIGHTS
 
     await role_dao.create(
         dto=RoleDTO(
@@ -1085,7 +1107,16 @@ async def test_modify_dn_rename_with_ap(
 
     aces_before = await access_control_entry_dao.get_all()
 
-    assert await try_modify() == LDAPCodes.SUCCESS
+    res = await run_single_modrdn(
+        settings=settings,
+        bind_dn="user_non_admin",
+        password=creds.pw,
+        dn=dn,
+        newrdn="cn=user2",
+        deleteoldrdn=1,
+    )
+
+    assert res == LDAPCodes.SUCCESS
 
     aces_after = await access_control_entry_dao.get_all()
 
@@ -1104,7 +1135,7 @@ async def test_modify_dn_rename_with_ap(
     assert inherited_aces_before == inherited_aces_after
     assert len(explicit_aces_after) == len(explicit_aces_before)
 
-    # check expicit aces have same properties except base_dn
+    # NOTE: Check explicit ACEs have same properties except base_dn
     for ace_before, ace_after in zip(
         explicit_aces_before,
         explicit_aces_after,
@@ -1141,38 +1172,17 @@ async def test_modify_dn_move_with_ap(
 
     new_parent_dn = "cn=Groups,dc=md,dc=test"
 
-    async def try_modify() -> int:
-        with tempfile.NamedTemporaryFile("w") as file:
-            file.write(
-                (
-                    f"dn: {dn}\n"
-                    "changetype: modrdn\n"
-                    "newrdn: cn=user2\n"
-                    "deleteoldrdn: 1\n"
-                    f"newsuperior: {new_parent_dn}\n"
-                ),
-            )
-            file.seek(0)
-            proc = await asyncio.create_subprocess_exec(
-                "ldapmodify",
-                "-vvv",
-                "-H",
-                f"ldap://{settings.HOST}:{settings.PORT}",
-                "-D",
-                "user_non_admin",
-                "-x",
-                "-w",
-                creds.pw,
-                "-f",
-                file.name,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
+    res = await run_single_modrdn(
+        settings=settings,
+        bind_dn="user_non_admin",
+        password=creds.pw,
+        dn=dn,
+        newrdn="cn=user2",
+        deleteoldrdn=1,
+        newsuperior=new_parent_dn,
+    )
 
-            await proc.communicate()
-            return await proc.wait()
-
-    assert await try_modify() == LDAPCodes.INSUFFICIENT_ACCESS_RIGHTS
+    assert res == LDAPCodes.INSUFFICIENT_ACCESS_RIGHTS
 
     await role_dao.create(
         dto=RoleDTO(
@@ -1208,7 +1218,17 @@ async def test_modify_dn_move_with_ap(
 
     aces_before = await access_control_entry_dao.get_all()
 
-    assert await try_modify() == LDAPCodes.SUCCESS
+    res = await run_single_modrdn(
+        settings=settings,
+        bind_dn="user_non_admin",
+        password=creds.pw,
+        dn=dn,
+        newrdn="cn=user2",
+        deleteoldrdn=1,
+        newsuperior=new_parent_dn,
+    )
+
+    assert res == LDAPCodes.SUCCESS
 
     aces_after = await access_control_entry_dao.get_all()
 


### PR DESCRIPTION
### Задача: 1256

### Изменения:
- Добавлена проверка прав на модификацию атрибута RDN для ModifyDN.
- Добавлена проверка на удаление директории, когда происходит перемещение директории.
- Исправлена обработка AccessControlEntry.
- В Delete запрос добавлена подгрузка EntityType, его авто-подгрузку в какой-то момент убрали и забыли добавить вручную.
- В подгрузку `ACE` добавлена подгрузка EntityType, его авто-подгрузку в какой-то момент убрали и забыли добавить вручную.
- Добавлены два теста - на переименование и перемещение.