### PR TITLE
Add: migration: add sAMAccountName to Computers

### DIFF
--- a/app/alembic/versions/df4287898910_add_samaccountname_to_computers.py
+++ b/app/alembic/versions/df4287898910_add_samaccountname_to_computers.py
@@ -1,0 +1,95 @@
+"""Add sAMAccountName attribute to Computer directories.
+
+Revision ID: df4287898910
+Revises: 19d86e660cf2
+Create Date: 2026-03-10 07:33:43.493288
+
+"""
+
+from alembic import op
+from dishka import AsyncContainer, Scope
+from sqlalchemy import exists, select
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession
+from sqlalchemy.orm import selectinload
+
+from entities import Attribute, Directory, EntityType
+from enums import EntityTypeNames
+from repo.pg.tables import queryable_attr as qa
+
+# revision identifiers, used by Alembic.
+revision: None | str = "df4287898910"
+down_revision: None | str = "19d86e660cf2"
+branch_labels: None | list[str] = None
+depends_on: None | list[str] = None
+
+
+def upgrade(container: AsyncContainer) -> None:
+    """Upgrade."""
+
+    async def _add_samaccountname_attr_to_computers(
+        connection: AsyncConnection,  # noqa: ARG001
+    ) -> None:
+        async with container(scope=Scope.REQUEST) as cnt:
+            session = await cnt.get(AsyncSession)
+
+        computer_dirs = await session.scalars(
+            select(Directory)
+            .join(qa(Directory.entity_type))
+            .options(
+                selectinload(qa(Directory.attributes)),
+                selectinload(qa(Directory.entity_type)),
+            )
+            .where(
+                qa(EntityType.name) == EntityTypeNames.COMPUTER,
+                ~exists(
+                    select(qa(Attribute.id))
+                    .where(
+                        qa(Attribute.directory_id) == qa(Directory.id),
+                        qa(Attribute.name) == "sAMAccountName",
+                    ),
+                ),
+            ),
+        )  # fmt: skip
+
+        for directory in computer_dirs:
+            session.add(
+                Attribute(
+                    name="sAMAccountName",
+                    value=directory.name,
+                    directory_id=directory.id,
+                ),
+            )
+
+        await session.commit()
+
+    op.run_async(_add_samaccountname_attr_to_computers)
+
+
+def downgrade(container: AsyncContainer) -> None:
+    """Downgrade."""
+
+    async def _remove_samaccountname_attr_from_computers(
+        connection: AsyncConnection,  # noqa: ARG001
+    ) -> None:
+        async with container(scope=Scope.REQUEST) as cnt:
+            session = await cnt.get(AsyncSession)
+
+        computer_dirs = await session.scalars(
+            select(Directory)
+            .join(qa(Directory.entity_type))
+            .options(
+                selectinload(qa(Directory.attributes)),
+                selectinload(qa(Directory.entity_type)),
+            )
+            .where(qa(EntityType.name) == EntityTypeNames.COMPUTER),
+        )
+
+        for directory in computer_dirs:
+            for attr in directory.attributes:
+                if attr.name == "sAMAccountName":
+                    await session.delete(attr)
+                    break
+
+        await session.commit()
+
+    op.run_async(_remove_samaccountname_attr_from_computers)

--- a/app/alembic/versions/df4287898910_add_samaccountname_to_computers.py
+++ b/app/alembic/versions/df4287898910_add_samaccountname_to_computers.py
@@ -8,9 +8,8 @@ Create Date: 2026-03-10 07:33:43.493288
 
 from alembic import op
 from dishka import AsyncContainer, Scope
-from sqlalchemy import exists, select
+from sqlalchemy import delete, exists, select
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession
-from sqlalchemy.orm import selectinload
 
 from entities import Attribute, Directory, EntityType
 from enums import EntityTypeNames
@@ -37,7 +36,6 @@ def upgrade(container: AsyncContainer) -> None:
         computer_dirs = await session.scalars(
             select(Directory)
             .join(qa(Directory.entity_type))
-            .options(selectinload(qa(Directory.attributes)))
             .where(
                 qa(EntityType.name) == EntityTypeNames.COMPUTER,
                 ~exists(
@@ -73,18 +71,17 @@ def downgrade(container: AsyncContainer) -> None:
         async with container(scope=Scope.REQUEST) as cnt:
             session = await cnt.get(AsyncSession)
 
-        computer_dirs = await session.scalars(
-            select(Directory)
+        computer_dir_ids = (
+            select(qa(Directory.id))
             .join(qa(Directory.entity_type))
-            .options(selectinload(qa(Directory.attributes)))
-            .where(qa(EntityType.name) == EntityTypeNames.COMPUTER),
+            .where(qa(EntityType.name) == EntityTypeNames.COMPUTER)
         )
-
-        for directory in computer_dirs:
-            for attr in directory.attributes:
-                if attr.name == _ATTR_NAME_SAMACCOUNTNAME:
-                    await session.delete(attr)
-                    break
+        await session.execute(
+            delete(Attribute).where(
+                qa(Attribute.name) == _ATTR_NAME_SAMACCOUNTNAME,
+                qa(Attribute.directory_id).in_(computer_dir_ids),
+            ),
+        )
 
         await session.commit()
 

--- a/app/alembic/versions/df4287898910_add_samaccountname_to_computers.py
+++ b/app/alembic/versions/df4287898910_add_samaccountname_to_computers.py
@@ -22,6 +22,8 @@ down_revision: None | str = "19d86e660cf2"
 branch_labels: None | list[str] = None
 depends_on: None | list[str] = None
 
+_ATTR_NAME_SAMACCOUNTNAME = "sAMAccountName"
+
 
 def upgrade(container: AsyncContainer) -> None:
     """Upgrade."""
@@ -35,17 +37,14 @@ def upgrade(container: AsyncContainer) -> None:
         computer_dirs = await session.scalars(
             select(Directory)
             .join(qa(Directory.entity_type))
-            .options(
-                selectinload(qa(Directory.attributes)),
-                selectinload(qa(Directory.entity_type)),
-            )
+            .options(selectinload(qa(Directory.attributes)))
             .where(
                 qa(EntityType.name) == EntityTypeNames.COMPUTER,
                 ~exists(
                     select(qa(Attribute.id))
                     .where(
                         qa(Attribute.directory_id) == qa(Directory.id),
-                        qa(Attribute.name) == "sAMAccountName",
+                        qa(Attribute.name) == _ATTR_NAME_SAMACCOUNTNAME,
                     ),
                 ),
             ),
@@ -54,7 +53,7 @@ def upgrade(container: AsyncContainer) -> None:
         for directory in computer_dirs:
             session.add(
                 Attribute(
-                    name="sAMAccountName",
+                    name=_ATTR_NAME_SAMACCOUNTNAME,
                     value=directory.name,
                     directory_id=directory.id,
                 ),
@@ -77,16 +76,13 @@ def downgrade(container: AsyncContainer) -> None:
         computer_dirs = await session.scalars(
             select(Directory)
             .join(qa(Directory.entity_type))
-            .options(
-                selectinload(qa(Directory.attributes)),
-                selectinload(qa(Directory.entity_type)),
-            )
+            .options(selectinload(qa(Directory.attributes)))
             .where(qa(EntityType.name) == EntityTypeNames.COMPUTER),
         )
 
         for directory in computer_dirs:
             for attr in directory.attributes:
-                if attr.name == "sAMAccountName":
+                if attr.name == _ATTR_NAME_SAMACCOUNTNAME:
                     await session.delete(attr)
                     break
 

--- a/app/ldap_protocol/ldap_requests/modify.py
+++ b/app/ldap_protocol/ldap_requests/modify.py
@@ -938,6 +938,8 @@ class ModifyRequest(BaseRequest):
                         await kadmin.modify_princ(
                             directory.user.sam_account_name,
                             new_sam_account_name,
+                            algorithms=None,
+                            password=None,
                         )
 
                         directory.user.user_principal_name = new_user_principal_name  # noqa: E501  # fmt: skip
@@ -1044,10 +1046,14 @@ class ModifyRequest(BaseRequest):
             await kadmin.modify_princ(
                 f"host/{old_sam_account_name}",
                 f"host/{new_sam_account_name}",
+                algorithms=None,
+                password=None,
             )
             await kadmin.modify_princ(
                 f"host/{old_sam_account_name}.{base_dir.name}",
                 f"host/{new_sam_account_name}.{base_dir.name}",
+                algorithms=None,
+                password=None,
             )
 
     async def _get_base_dir(


### PR DESCRIPTION
Дано:
В рамках ПР https://github.com/MultiDirectoryLab/MultiDirectory/pull/925 к Директориям-Компьютерам при создании добавляется атрибут `sAMAccountName`.

Проблема:
К уже существующим Директориям-Компьютерам не был добавлен атрибут `sAMAccountName`.

Решение:
Через миграцию добавить к уже существующим Директориям-Компьютерам атрибут `sAMAccountName`.

Задача: 1364