### PR TITLE
Refactor: replace lDAPDisplayName to dir.name

### DIFF
--- a/app/ldap_protocol/ldap_schema/attribute_type/attribute_type_dao.py
+++ b/app/ldap_protocol/ldap_schema/attribute_type/attribute_type_dao.py
@@ -22,7 +22,7 @@ from repo.pg.tables import queryable_attr as qa
 def _convert_model_to_dto(directory: Directory) -> AttributeTypeDTO[int]:
     return AttributeTypeDTO[int](
         id=directory.id,
-        name=directory.attributes_dict[Names.LDAP_DISPLAY_NAME][0],
+        name=directory.name,
         ldap_display_name=directory.attributes_dict[Names.LDAP_DISPLAY_NAME][0],
         oid=directory.attributes_dict[Names.OID][0],
         syntax=directory.attributes_dict[Names.SYNTAX][0],

--- a/tests/test_api/test_ldap_schema/test_attribute_type_router.py
+++ b/tests/test_api/test_ldap_schema/test_attribute_type_router.py
@@ -79,6 +79,18 @@ async def test_create_attribute_type_conflict_when_already_exists(
 
 
 @pytest.mark.asyncio
+async def test_get_attribute_type_returns_directory_name(
+    http_client: AsyncClient,
+) -> None:
+    """Test name vs ldap_display_name for attribute type responses."""
+    response = await http_client.get("/schema/attribute_type/attr_with_bvalue")
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data.get("name") == "attr_with_bvalue"
+    assert data.get("ldap_display_name") == "attrWithBvalue"
+
+
+@pytest.mark.asyncio
 async def test_get_list_attribute_types_with_pagination(
     http_client: AsyncClient,
 ) -> None:


### PR DESCRIPTION
На фронт мы отдаем ldapDisplayName и затем фронт отправляет на бек значение из ldapDisplayName для поиска по Directory.name, это неправильно

Нужна правка в UI. 