### PR TITLE
Fix: migrations downgrade config, mapping error, schema paginator not case sensitive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ launch:  ## run standalone app without tty container
 	docker compose run sh -c "python multidirectory.py --migrate && python ."
 
 rerun_last_migration:
-	docker exec -it multidirectory_api sh -c "alembic downgrade -1; python multidirectory.py --migrate;"
+	docker exec -it multidirectory_api sh -c "python multidirectory.py --downgrade -2; python multidirectory.py --migrate;"
 
 rerun_all_migrations:
-	docker exec -it multidirectory_api sh -c "alembic downgrade base; python multidirectory.py --migrate;"
+	docker exec -it multidirectory_api sh -c "python multidirectory.py --downgrade base; python multidirectory.py --migrate;"
 
 down:  ## shutdown services
 	docker compose -f docker-compose.test.yml down --remove-orphans

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ launch:  ## run standalone app without tty container
 	docker compose run sh -c "python multidirectory.py --migrate && python ."
 
 rerun_last_migration:
-	docker exec -it multidirectory_api sh -c "python multidirectory.py --downgrade -2; python multidirectory.py --migrate;"
+	docker exec -it multidirectory_api sh -c "python multidirectory.py --downgrade -1; python multidirectory.py --migrate;"
 
 rerun_all_migrations:
 	docker exec -it multidirectory_api sh -c "python multidirectory.py --downgrade base; python multidirectory.py --migrate;"

--- a/app/alembic/versions/21a957c18dce_create_directory_name_indexes.py
+++ b/app/alembic/versions/21a957c18dce_create_directory_name_indexes.py
@@ -21,11 +21,11 @@ def upgrade(container: AsyncContainer) -> None:  # noqa: ARG001
     """Upgrade."""
     op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
     op.create_index(
-        "idx_Directory_name_btree",
+        "idx_Directory_name_hash",
         "Directory",
         ["name"],
         unique=False,
-        postgresql_using="btree",
+        postgresql_using="hash",
     )
     op.create_index(
         "idx_Directory_name_gin_trgm",
@@ -41,10 +41,8 @@ def downgrade(container: AsyncContainer) -> None:  # noqa: ARG001
     op.drop_index(
         "idx_Directory_name_gin_trgm",
         table_name="Directory",
-        postgresql_using="gin",
     )
     op.drop_index(
-        "idx_Directory_name_btree",
+        "idx_Directory_name_hash",
         table_name="Directory",
-        postgresql_using="btree",
     )

--- a/app/alembic/versions/21a957c18dce_create_directory_name_indexes.py
+++ b/app/alembic/versions/21a957c18dce_create_directory_name_indexes.py
@@ -1,0 +1,50 @@
+"""Create Directory.name indexes.
+
+Revision ID: 21a957c18dce
+Revises: 1b71cafba681
+Create Date: 2026-04-10 11:15:22.133564
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from dishka import AsyncContainer
+
+# revision identifiers, used by Alembic.
+revision: None | str = "21a957c18dce"
+down_revision: None | str = "1b71cafba681"
+branch_labels: None | list[str] = None
+depends_on: None | list[str] = None
+
+
+def upgrade(container: AsyncContainer) -> None:  # noqa: ARG001
+    """Upgrade."""
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    op.create_index(
+        "idx_Directory_name_btree",
+        "Directory",
+        ["name"],
+        unique=False,
+        postgresql_using="btree",
+    )
+    op.create_index(
+        "idx_Directory_name_gin_trgm",
+        "Directory",
+        [sa.literal_column("name gin_trgm_ops")],
+        unique=False,
+        postgresql_using="gin",
+    )
+
+
+def downgrade(container: AsyncContainer) -> None:  # noqa: ARG001
+    """Downgrade."""
+    op.drop_index(
+        "idx_Directory_name_gin_trgm",
+        table_name="Directory",
+        postgresql_using="gin",
+    )
+    op.drop_index(
+        "idx_Directory_name_btree",
+        table_name="Directory",
+        postgresql_using="btree",
+    )

--- a/app/api/ldap_schema/__init__.py
+++ b/app/api/ldap_schema/__init__.py
@@ -18,6 +18,7 @@ from api.error_routing import (
     DomainErrorTranslator,
 )
 from enums import DomainCodes
+from ldap_protocol.identity.exceptions import UnauthorizedError
 from ldap_protocol.ldap_schema.exceptions import (
     AttributeTypeAlreadyExistsError,
     AttributeTypeCantModifyError,
@@ -40,6 +41,10 @@ translator = DomainErrorTranslator(DomainCodes.LDAP_SCHEMA)
 
 
 error_map: ERROR_MAP_TYPE = {
+    UnauthorizedError: rule(
+        status=status.HTTP_401_UNAUTHORIZED,
+        translator=translator,
+    ),
     AttributeTypeAlreadyExistsError: rule(
         status=status.HTTP_400_BAD_REQUEST,
         translator=translator,

--- a/app/ldap_protocol/ldap_schema/_legacy/attribute_type/attribute_type_dao.py
+++ b/app/ldap_protocol/ldap_schema/_legacy/attribute_type/attribute_type_dao.py
@@ -30,7 +30,7 @@ def _convert_model_to_dto(
     )
     return AttributeTypeDTO[int](
         oid=attr_type.oid,
-        name=ldap_display_name,
+        name=attr_type.name,
         ldap_display_name=ldap_display_name,
         syntax=attr_type.syntax,
         single_value=attr_type.single_value,

--- a/app/ldap_protocol/ldap_schema/attribute_type/attribute_type_dao.py
+++ b/app/ldap_protocol/ldap_schema/attribute_type/attribute_type_dao.py
@@ -144,7 +144,7 @@ class AttributeTypeDAO:
         filters = [qa(EntityType.name) == EntityTypeNames.ATTRIBUTE_TYPE]
 
         if params.query:
-            filters.append(qa(Directory.name).like(f"%{params.query}%"))
+            filters.append(qa(Directory.name).ilike(f"%{params.query}%"))
 
         query = (
             select(Directory)

--- a/app/ldap_protocol/ldap_schema/object_class/object_class_dao.py
+++ b/app/ldap_protocol/ldap_schema/object_class/object_class_dao.py
@@ -116,7 +116,7 @@ class ObjectClassDAO:
         filters = [qa(EntityType.name) == EntityTypeNames.OBJECT_CLASS]
 
         if params.query:
-            filters.append(qa(Directory.name).like(f"%{params.query}%"))
+            filters.append(qa(Directory.name).ilike(f"%{params.query}%"))
 
         query = (
             select(Directory)

--- a/app/multidirectory.py
+++ b/app/multidirectory.py
@@ -351,6 +351,11 @@ if __name__ == "__main__":
         help="Make migrations",
     )
     group.add_argument(
+        "--downgrade",
+        metavar="REV",
+        help="Downgrade database to revision",
+    )
+    group.add_argument(
         "--migrate_dns",
         action="store_true",
         help="Migrate DNS from BIND to PowerDNS",
@@ -397,5 +402,7 @@ if __name__ == "__main__":
         dump_acme_cert()
     elif args.migrate:
         command.upgrade(Config("alembic.ini"), "head")
+    elif args.downgrade:
+        command.downgrade(Config("alembic.ini"), args.downgrade)
     elif args.migrate_dns:
         dns_migration(settings=settings)

--- a/app/repo/pg/tables.py
+++ b/app/repo/pg/tables.py
@@ -169,6 +169,8 @@ directory_table = Table(
         text("array_lowercase(path)"),
         postgresql_using="hash",
     ),
+    Index("idx_Directory_name_btree", "name", postgresql_using="btree"),
+    Index("idx_Directory_name_gin_trgm", "name", postgresql_using="gin"),
 )
 
 groups_table = Table(

--- a/app/repo/pg/tables.py
+++ b/app/repo/pg/tables.py
@@ -169,7 +169,7 @@ directory_table = Table(
         text("array_lowercase(path)"),
         postgresql_using="hash",
     ),
-    Index("idx_Directory_name_btree", "name", postgresql_using="btree"),
+    Index("idx_Directory_name_hash", "name", postgresql_using="hash"),
     Index("idx_Directory_name_gin_trgm", "name", postgresql_using="gin"),
 )
 

--- a/tests/test_api/test_ldap_schema/test_attribute_type_router.py
+++ b/tests/test_api/test_ldap_schema/test_attribute_type_router.py
@@ -106,6 +106,20 @@ async def test_get_list_attribute_types_with_pagination(
 
 
 @pytest.mark.asyncio
+async def test_attribute_type_pagination_search_is_case_insensitive(
+    http_client: AsyncClient,
+) -> None:
+    """Test case-insensitive search for attribute type pagination."""
+    response = await http_client.get(
+        "/schema/attribute_types",
+        params={"page_number": 1, "page_size": 50, "query": "PoSiXeMaIl"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    items = response.json().get("items", [])
+    assert any(item.get("name") == "posixEmail" for item in items)
+
+
+@pytest.mark.asyncio
 async def test_modify_one_attribute_type_raise_404(
     http_client: AsyncClient,
 ) -> None:

--- a/tests/test_api/test_ldap_schema/test_object_class_router.py
+++ b/tests/test_api/test_ldap_schema/test_object_class_router.py
@@ -133,6 +133,20 @@ async def test_get_list_object_classes_with_pagination(
     assert len(response.json().get("items")) == page_size
 
 
+@pytest.mark.asyncio
+async def test_object_class_pagination_search_is_case_insensitive(
+    http_client: AsyncClient,
+) -> None:
+    """Test case-insensitive search for object class pagination."""
+    response = await http_client.get(
+        "/schema/object_classes",
+        params={"page_number": 1, "page_size": 50, "query": "InEtOrGpErSoN"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    items = response.json().get("items", [])
+    assert any(item.get("name") == "inetOrgPerson" for item in items)
+
+
 @pytest.mark.parametrize(
     "dataset",
     test_modify_one_object_class_dataset,


### PR DESCRIPTION
Часть правок связаны с задачей 1258

- На downgrade для БД теперь отдельная команда, нужна для того, чтобы в Э можно было проверить лицензицию
- Пагинатор обжектКлассов и атрибутТипов регистронезависимый + тесты на это
- Добавил мапинг ошибки HTTP_401_UNAUTHORIZED для схемы
- В legacy/attribute_type_dao исправил присвоение для свойства `name`